### PR TITLE
Combine metrics of discovery server and controller manager

### DIFF
--- a/cmd/discovery-server/app/app.go
+++ b/cmd/discovery-server/app/app.go
@@ -96,7 +96,7 @@ func run(ctx context.Context, log logr.Logger, opts *options.Config) error {
 		Metrics: metricsserver.Options{
 			BindAddress: net.JoinHostPort("", "8080"),
 		},
-		GracefulShutdownTimeout: ptr.To(5 * time.Second),
+		GracefulShutdownTimeout: ptr.To(10 * time.Second),
 		LeaderElection:          false,
 		PprofBindAddress:        "",
 		HealthProbeBindAddress:  net.JoinHostPort("", "8081"),

--- a/cmd/discovery-server/app/app.go
+++ b/cmd/discovery-server/app/app.go
@@ -18,7 +18,6 @@ import (
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/go-logr/logr"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
@@ -96,9 +95,6 @@ func run(ctx context.Context, log logr.Logger, opts *options.Config) error {
 		Scheme: kubernetes.GardenScheme,
 		Metrics: metricsserver.Options{
 			BindAddress: net.JoinHostPort("", "8080"),
-			ExtraHandlers: map[string]http.Handler{
-				"/metrics/discovery-server": promhttp.Handler(),
-			},
 		},
 		GracefulShutdownTimeout: ptr.To(5 * time.Second),
 		LeaderElection:          false,

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -9,10 +9,12 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 func init() {
 	prometheus.MustRegister(requestLatency, requestTotal, requestInFlight)
+	metrics.Registry.MustRegister(requestLatency, requestTotal, requestInFlight)
 }
 
 const (


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it**:
I thought that I addressed this https://github.com/gardener/gardener-discovery-server/pull/6#discussion_r1577392386 but it seems that I have forgotten.

Let's combine both metrics for now. We can split them later if needed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
