### PR TITLE
Implement e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ VERSION                     := $(shell cat "$(REPO_ROOT)/VERSION")
 GOARCH                      ?= $(shell go env GOARCH)
 EFFECTIVE_VERSION           := $(VERSION)-$(shell git rev-parse HEAD)
 LD_FLAGS                    := "-w $(shell bash $(GARDENER_HACK_DIR)/get-build-ld-flags.sh k8s.io/component-base $(REPO_ROOT)/VERSION $(NAME))"
+PARALLEL_E2E_TESTS          := 2
 
 ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
 	EFFECTIVE_VERSION := $(EFFECTIVE_VERSION)-dirty
@@ -102,3 +103,9 @@ server-dev: $(SKAFFOLD) $(HELM)
 
 server-down: $(SKAFFOLD) $(HELM)
 	$(SKAFFOLD) delete
+
+test-e2e-local: $(GINKGO) $(KUBECTL)
+	./hack/test-e2e-local.sh --procs=$(PARALLEL_E2E_TESTS) ./test/e2e/...
+
+ci-e2e-kind:
+	./hack/ci-e2e-kind.sh

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/fluent/fluent-operator/v2 v2.8.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/gardener/cert-management v0.14.2 // indirect
 	github.com/gardener/etcd-druid v0.22.0 // indirect
 	github.com/gardener/hvpa-controller/api v0.15.0 // indirect
 	github.com/gardener/machine-controller-manager v0.53.0 // indirect
@@ -71,6 +72,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -119,6 +121,7 @@ require (
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-aggregator v0.29.4 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
+	k8s.io/kubelet v0.29.4 // indirect
 	k8s.io/metrics v0.29.4 // indirect
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20231015215740-bf15e44028f9 // indirect
 	sigs.k8s.io/controller-tools v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+github.com/gardener/cert-management v0.14.2 h1:dlrPblsUIIjMaDPfZyYXvO3OKDkAlHSjbdZO1c6HASQ=
+github.com/gardener/cert-management v0.14.2/go.mod h1:dfhuPXJn+yy9OoSSxY/HAMiwzD2IOqoM+UMx16QTkvI=
 github.com/gardener/etcd-druid v0.22.0 h1:DVe+Zjrb93r9vI1uUiCTMHBffIUoMAKhNzFZNC6hsQ8=
 github.com/gardener/etcd-druid v0.22.0/go.mod h1:FROhfVKyWBo4krlPe3R6FIhJRmOmijEWBdEeUP0CJjE=
 github.com/gardener/gardener v1.94.1 h1:d7iPX4F0z97oc8EABfilV9M4o4hrqbN8c3lBFXyualk=
@@ -247,6 +249,8 @@ github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQth
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
@@ -588,6 +592,8 @@ k8s.io/apiextensions-apiserver v0.29.4/go.mod h1:TTDC9fB+0kHY2rogf5hgBR03KBKCwED
 k8s.io/apimachinery v0.19.0/go.mod h1:DnPGDnARWFvYa3pMHgSxtbZb7gpzzAZ1pTfaUNDVlmA=
 k8s.io/apimachinery v0.29.4 h1:RaFdJiDmuKs/8cm1M6Dh1Kvyh59YQFDcFuFTSmXes6Q=
 k8s.io/apimachinery v0.29.4/go.mod h1:i3FJVwhvSp/6n8Fl4K97PJEP8C+MM+aoDq4+ZJBf70Y=
+k8s.io/apiserver v0.29.4 h1:wPwGOO58GQOpRiZu59P5eRoDcB7QtV+QBglkRiXwCiM=
+k8s.io/apiserver v0.29.4/go.mod h1:VqTF9t98HVfhKZVRohCPezsdUt9u2g3bHKftxGcXoRo=
 k8s.io/autoscaler/vertical-pod-autoscaler v1.1.1 h1:cz1xqf+WccJcvEaDd9sefJVx7bEldJT5RLQWViRgoTI=
 k8s.io/autoscaler/vertical-pod-autoscaler v1.1.1/go.mod h1:J2cNKnieE7r4bInjpQDBq93D50aD/CmspSi6xRUfKk4=
 k8s.io/client-go v0.19.0/go.mod h1:H9E/VT95blcFQnlyShFgnFT9ZnJOAceiUHM3MlRC+mU=

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o nounset
+set -o pipefail
+set -o errexit
+
+clamp_mss_to_pmtu() {
+  # https://github.com/kubernetes/test-infra/issues/23741
+  if [[ "$OSTYPE" != "darwin"* ]]; then
+    iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+  fi
+}
+
+REPO_ROOT="$(readlink -f $(dirname ${0})/..)"
+GARDENER_VERSION=$(go list -m -f '{{.Version}}' github.com/gardener/gardener)
+
+if [[ ! -d "$REPO_ROOT/gardener" ]]; then
+  git clone --branch $GARDENER_VERSION https://github.com/gardener/gardener.git
+else
+  (cd "$REPO_ROOT/gardener" && git checkout $GARDENER_VERSION)
+fi
+
+clamp_mss_to_pmtu
+
+make -C "$REPO_ROOT/gardener" kind-up
+export KUBECONFIG=$REPO_ROOT/gardener/example/gardener-local/kind/local/kubeconfig
+
+trap '{
+  make -C "$REPO_ROOT/gardener" kind-down
+}' EXIT
+
+make -C "$REPO_ROOT/gardener" gardener-up
+make server-up
+make test-e2e-local
+make server-down
+make -C "$REPO_ROOT/gardener" gardener-down

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "> E2E Tests"
+
+GO111MODULE=on ginkgo run --timeout=1h --v --show-node-events "$@"

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -46,12 +46,7 @@ func defaultShoot(generateName string) *gardencorev1beta1.Shoot {
 			SecretBindingName: ptr.To("local"),
 			CloudProfileName:  "local",
 			Kubernetes: gardencorev1beta1.Kubernetes{
-				Version: "1.28.2",
-				Kubelet: &gardencorev1beta1.KubeletConfig{
-					SerializeImagePulls: ptr.To(false),
-					RegistryPullQPS:     ptr.To[int32](10),
-					RegistryBurst:       ptr.To[int32](20),
-				},
+				Version:       "1.28.2",
 				KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
 			},
 			Networking: &gardencorev1beta1.Networking{
@@ -82,9 +77,9 @@ func addAnnotations(shoot *gardencorev1beta1.Shoot) error {
 	return nil
 }
 
-func getJWKSForShoot(shootUID types.UID) (*http.Response, error) {
+func getJWKSForShoot(ctx context.Context, shootUID types.UID) (*http.Response, error) {
 	uri := discoveryServerBaseURI + "/projects/local/shoots/" + string(shootUID) + "/issuer/jwks"
-	ctx, cancel := context.WithTimeout(parentCtx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
@@ -94,9 +89,9 @@ func getJWKSForShoot(shootUID types.UID) (*http.Response, error) {
 	return discoveryClient.Do(req)
 }
 
-func getWellKnownForShoot(shootUID types.UID) (*http.Response, error) {
+func getWellKnownForShoot(ctx context.Context, shootUID types.UID) (*http.Response, error) {
 	uri := discoveryServerBaseURI + "/projects/local/shoots/" + string(shootUID) + "/issuer/.well-known/openid-configuration"
-	ctx, cancel := context.WithTimeout(parentCtx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/test/framework"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+)
+
+const projectNamespace = "garden-local"
+
+func defaultShootCreationFramework() *framework.ShootCreationFramework {
+	kubeconfigPath := os.Getenv("KUBECONFIG")
+	return framework.NewShootCreationFramework(&framework.ShootCreationConfig{
+		GardenerConfig: &framework.GardenerConfig{
+			ProjectNamespace:   projectNamespace,
+			GardenerKubeconfig: kubeconfigPath,
+			SkipAccessingShoot: true,
+			CommonConfig:       &framework.CommonConfig{},
+		},
+	})
+}
+
+func defaultShoot(generateName string) *gardencorev1beta1.Shoot {
+	return &gardencorev1beta1.Shoot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: generateName,
+			Annotations: map[string]string{
+				v1beta1constants.AnnotationShootCloudConfigExecutionMaxDelaySeconds: "0",
+			},
+		},
+		Spec: gardencorev1beta1.ShootSpec{
+			Region:            "local",
+			SecretBindingName: ptr.To("local"),
+			CloudProfileName:  "local",
+			Kubernetes: gardencorev1beta1.Kubernetes{
+				Version: "1.28.2",
+				Kubelet: &gardencorev1beta1.KubeletConfig{
+					SerializeImagePulls: ptr.To(false),
+					RegistryPullQPS:     ptr.To[int32](10),
+					RegistryBurst:       ptr.To[int32](20),
+				},
+				KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
+			},
+			Networking: &gardencorev1beta1.Networking{
+				Type:           ptr.To("calico"),
+				ProviderConfig: &runtime.RawExtension{Raw: []byte(`{"apiVersion":"calico.networking.extensions.gardener.cloud/v1alpha1","kind":"NetworkConfig","typha":{"enabled":false},"backend":"none"}`)},
+			},
+			Provider: gardencorev1beta1.Provider{
+				Type: "local",
+				Workers: []gardencorev1beta1.Worker{{
+					Name: "local",
+					Machine: gardencorev1beta1.Machine{
+						Type: "local",
+					},
+					CRI: &gardencorev1beta1.CRI{
+						Name: gardencorev1beta1.CRINameContainerD,
+					},
+					Minimum: 1,
+					Maximum: 1,
+				}},
+			},
+		},
+	}
+}
+
+func addAnnotations(shoot *gardencorev1beta1.Shoot) error {
+	shoot.Annotations[v1beta1constants.AnnotationAuthenticationIssuer] = v1beta1constants.AnnotationAuthenticationIssuerManaged
+	shoot.Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationReconcile
+	return nil
+}
+
+func getJWKSForShoot(shootUID types.UID) (*http.Response, error) {
+	uri := discoveryServerBaseURI + "/projects/local/shoots/" + string(shootUID) + "/issuer/jwks"
+	ctx, cancel := context.WithTimeout(parentCtx, 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return discoveryClient.Do(req)
+}
+
+func getWellKnownForShoot(shootUID types.UID) (*http.Response, error) {
+	uri := discoveryServerBaseURI + "/projects/local/shoots/" + string(shootUID) + "/issuer/.well-known/openid-configuration"
+	ctx, cancel := context.WithTimeout(parentCtx, 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return discoveryClient.Do(req)
+}

--- a/test/e2e/create_enable_delete_test.go
+++ b/test/e2e/create_enable_delete_test.go
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/test/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Managed Issuer Tests", Label("ManagedIssuer"), func() {
+	f := defaultShootCreationFramework()
+	f.Shoot = defaultShoot("e2e-default")
+
+	It("Create Shoot, Enable Managed Issuer, Delete Shoot", Label("good-case"), func() {
+		By("Create Shoot")
+		ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
+		defer cancel()
+		Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
+		f.Verify()
+
+		resp, err := getWellKnownForShoot(f.Shoot.ObjectMeta.UID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+
+		resp, err = getJWKSForShoot(f.Shoot.ObjectMeta.UID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+
+		By("Enable Managed Issuer")
+		ctx, cancel = context.WithTimeout(parentCtx, 5*time.Minute)
+		defer cancel()
+		Expect(f.UpdateShoot(ctx, f.Shoot, addAnnotations)).To(Succeed())
+
+		By("Check that the Discovery Server is able to serve the shoot's OIDC discovery documents")
+		resp, err = getWellKnownForShoot(f.Shoot.ObjectMeta.UID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		defer resp.Body.Close()
+		wellKnownBytes, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		var wellKnown map[string]any
+		Expect(json.Unmarshal(wellKnownBytes, &wellKnown)).To(Succeed())
+		iss, ok := wellKnown["issuer"].(string)
+		Expect(ok).To(BeTrue())
+		Expect(strings.HasPrefix(iss, "https://")).To(BeTrue())
+		Expect(strings.HasSuffix(iss, "/issuer")).To(BeTrue())
+		jwksURI, ok := wellKnown["jwks_uri"].(string)
+		Expect(ok).To(BeTrue())
+		Expect(strings.HasPrefix(jwksURI, "https://")).To(BeTrue())
+		Expect(strings.HasSuffix(jwksURI, "/issuer/jwks")).To(BeTrue())
+
+		resp, err = getJWKSForShoot(f.Shoot.ObjectMeta.UID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		defer resp.Body.Close()
+		jwks, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+
+		keySet := jose.JSONWebKeySet{}
+		Expect(json.Unmarshal(jwks, &keySet)).To(Succeed())
+		Expect(keySet.Keys).To(HaveLen(1))
+		pubKey, ok := (keySet.Keys[0].Key).(*rsa.PublicKey)
+		Expect(ok).To(BeTrue())
+
+		_, seedClient, err := f.GetSeed(ctx, *f.Shoot.Status.SeedName)
+		Expect(err).ToNot(HaveOccurred())
+		project, err := f.GetShootProject(ctx, f.Shoot.Namespace)
+		Expect(err).ToNot(HaveOccurred())
+		shootSeedNamespace := framework.ComputeTechnicalID(project.Name, f.Shoot)
+
+		By("Check that the received public key is indeed the same public key that resides in the seed")
+		secretList := &corev1.SecretList{}
+		Expect(seedClient.Client().List(ctx, secretList, client.InNamespace(shootSeedNamespace), client.MatchingLabels{"bundle-for": "service-account-key"})).To(Succeed())
+		Expect(secretList.Items).To(HaveLen(1))
+
+		keyBundleBlock, _ := pem.Decode(secretList.Items[0].Data["bundle.key"])
+		rsaKey, err := x509.ParsePKCS1PrivateKey(keyBundleBlock.Bytes)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rsaKey.PublicKey.Equal(pubKey)).To(BeTrue())
+
+		By("Delete Shoot")
+		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
+		defer cancel()
+		Expect(f.DeleteShootAndWaitForDeletion(ctx, f.Shoot)).To(Succeed())
+
+		resp, err = getWellKnownForShoot(f.Shoot.ObjectMeta.UID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+
+		resp, err = getJWKSForShoot(f.Shoot.ObjectMeta.UID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+	})
+})

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"os"
+	"os/exec"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "E2E Test Suite")
+}
+
+const (
+	discoveryServerBaseURI = "https://localhost:10443"
+)
+
+var (
+	cmd             *exec.Cmd
+	parentCtx       = context.Background()
+	discoveryClient *http.Client
+)
+
+var _ = BeforeEach(func() {
+	parentCtx = context.Background()
+})
+
+var _ = BeforeSuite(func() {
+	cmd = exec.Command("kubectl", "-n", "garden", "port-forward", "service/gardener-discovery-server", "10443:10443")
+	Expect(cmd.Start()).To(Succeed())
+
+	kubeconfigPath := os.Getenv("KUBECONFIG")
+	kubeconfigBytes, err := os.ReadFile(kubeconfigPath)
+	Expect(err).ToNot(HaveOccurred())
+
+	cfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigBytes)
+	Expect(err).ToNot(HaveOccurred())
+	clientset, err := kubernetes.NewForConfig(cfg)
+	Expect(err).ToNot(HaveOccurred())
+
+	secret, err := clientset.CoreV1().Secrets("garden").Get(parentCtx, "gardener-discovery-server-tls", metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred())
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(secret.Data["tls.crt"])
+	discoveryClient = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: pool,
+			},
+		},
+	}
+
+})
+
+var _ = AfterSuite(func() {
+	Expect(cmd.Process.Kill()).To(Succeed())
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an e2e test that can be ran in prow in order to verify the functionality of the discovery server. Depends on https://github.com/gardener/gardener-discovery-server/pull/19

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
