### PR TITLE
Set HSTS header if not already set

### DIFF
--- a/internal/handler/openidmeta/handler.go
+++ b/internal/handler/openidmeta/handler.go
@@ -42,6 +42,7 @@ func New(store store.Reader, log logr.Logger) *Handler {
 // HandleWellKnown handles /.well-known/openid-configuration.
 // It requires "projectName" and "shootUID" as path parameters.
 func (h *Handler) HandleWellKnown(w http.ResponseWriter, r *http.Request) {
+	setHSTS(w)
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		w.Header().Set(headerContentType, mimeAppJSON)
 		w.WriteHeader(http.StatusMethodNotAllowed)
@@ -81,6 +82,7 @@ func (h *Handler) HandleWellKnown(w http.ResponseWriter, r *http.Request) {
 // HandleJWKS handles JWKS response.
 // It requires "projectName" and "shootUID" as path parameters.
 func (h *Handler) HandleJWKS(w http.ResponseWriter, r *http.Request) {
+	setHSTS(w)
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		w.Header().Set(headerContentType, mimeAppJSON)
 		w.WriteHeader(http.StatusMethodNotAllowed)
@@ -118,10 +120,17 @@ func (h *Handler) HandleJWKS(w http.ResponseWriter, r *http.Request) {
 
 // HandleNotFound writes a not found response to writer.
 func (h *Handler) HandleNotFound(w http.ResponseWriter, _ *http.Request) {
+	setHSTS(w)
 	w.Header().Set(headerContentType, mimeAppJSON)
 	w.WriteHeader(http.StatusNotFound)
 	if _, err := w.Write([]byte(responseNotFound)); err != nil {
 		h.log.Error(err, "Failed writing response")
 		return
+	}
+}
+
+func setHSTS(w http.ResponseWriter) {
+	if w.Header().Get("Strict-Transport-Security") == "" {
+		w.Header().Set("Strict-Transport-Security", "max-age=31536000")
 	}
 }

--- a/internal/handler/openidmeta/handler_test.go
+++ b/internal/handler/openidmeta/handler_test.go
@@ -68,8 +68,9 @@ var _ = Describe("#HttpHandlerOpenIDMeta", func() {
 			200,
 			[]byte("config1"),
 			map[string]string{
-				"Content-Type":  "application/json",
-				"Cache-Control": "public, max-age=3600",
+				"Strict-Transport-Security": "max-age=31536000",
+				"Content-Type":              "application/json",
+				"Cache-Control":             "public, max-age=3600",
 			},
 		),
 		Entry(
@@ -79,8 +80,9 @@ var _ = Describe("#HttpHandlerOpenIDMeta", func() {
 			200,
 			[]byte("jwks1"),
 			map[string]string{
-				"Content-Type":  "application/json",
-				"Cache-Control": "public, max-age=3600",
+				"Strict-Transport-Security": "max-age=31536000",
+				"Content-Type":              "application/json",
+				"Cache-Control":             "public, max-age=3600",
 			},
 		),
 		Entry(
@@ -90,8 +92,9 @@ var _ = Describe("#HttpHandlerOpenIDMeta", func() {
 			200,
 			[]byte("config2"),
 			map[string]string{
-				"Content-Type":  "application/json",
-				"Cache-Control": "public, max-age=3600",
+				"Strict-Transport-Security": "max-age=31536000",
+				"Content-Type":              "application/json",
+				"Cache-Control":             "public, max-age=3600",
 			},
 		),
 		Entry(
@@ -101,8 +104,9 @@ var _ = Describe("#HttpHandlerOpenIDMeta", func() {
 			200,
 			[]byte("jwks2"),
 			map[string]string{
-				"Content-Type":  "application/json",
-				"Cache-Control": "public, max-age=3600",
+				"Strict-Transport-Security": "max-age=31536000",
+				"Content-Type":              "application/json",
+				"Cache-Control":             "public, max-age=3600",
 			},
 		),
 		Entry(
@@ -112,7 +116,8 @@ var _ = Describe("#HttpHandlerOpenIDMeta", func() {
 			404,
 			[]byte(`{"code":404,"message":"not found"}`),
 			map[string]string{
-				"Content-Type": "application/json",
+				"Strict-Transport-Security": "max-age=31536000",
+				"Content-Type":              "application/json",
 			},
 		),
 		Entry(
@@ -122,7 +127,8 @@ var _ = Describe("#HttpHandlerOpenIDMeta", func() {
 			404,
 			[]byte(`{"code":404,"message":"not found"}`),
 			map[string]string{
-				"Content-Type": "application/json",
+				"Strict-Transport-Security": "max-age=31536000",
+				"Content-Type":              "application/json",
 			},
 		),
 		Entry(
@@ -132,7 +138,8 @@ var _ = Describe("#HttpHandlerOpenIDMeta", func() {
 			400,
 			[]byte(`{"code":400,"message":"bad request"}`),
 			map[string]string{
-				"Content-Type": "application/json",
+				"Strict-Transport-Security": "max-age=31536000",
+				"Content-Type":              "application/json",
 			},
 		),
 		Entry(
@@ -142,7 +149,8 @@ var _ = Describe("#HttpHandlerOpenIDMeta", func() {
 			400,
 			[]byte(`{"code":400,"message":"bad request"}`),
 			map[string]string{
-				"Content-Type": "application/json",
+				"Strict-Transport-Security": "max-age=31536000",
+				"Content-Type":              "application/json",
 			},
 		),
 		Entry(
@@ -152,7 +160,8 @@ var _ = Describe("#HttpHandlerOpenIDMeta", func() {
 			404,
 			[]byte(`{"code":404,"message":"not found"}`),
 			map[string]string{
-				"Content-Type": "application/json",
+				"Strict-Transport-Security": "max-age=31536000",
+				"Content-Type":              "application/json",
 			},
 		),
 		Entry(
@@ -162,7 +171,8 @@ var _ = Describe("#HttpHandlerOpenIDMeta", func() {
 			405,
 			[]byte(`{"code":405,"message":"method not allowed"}`),
 			map[string]string{
-				"Content-Type": "application/json",
+				"Strict-Transport-Security": "max-age=31536000",
+				"Content-Type":              "application/json",
 			},
 		),
 		Entry(
@@ -172,7 +182,8 @@ var _ = Describe("#HttpHandlerOpenIDMeta", func() {
 			405,
 			[]byte(`{"code":405,"message":"method not allowed"}`),
 			map[string]string{
-				"Content-Type": "application/json",
+				"Strict-Transport-Security": "max-age=31536000",
+				"Content-Type":              "application/json",
 			},
 		),
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
/kind enhancement

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The "/.well-known/openid-configuration" and "jwks" endpoints of the discovery server now set the "Strict-Transport-Security" header.
```
