### PR TITLE
Add workflow to automatically call make tidy on g/g update PRs

### DIFF
--- a/.github/workflows/update_gardener.yaml
+++ b/.github/workflows/update_gardener.yaml
@@ -1,0 +1,31 @@
+name: Update Gardener
+on:
+  push:
+    branches:
+    - dependabot/go_modules/github.com/gardener/**
+permissions: write-all
+jobs:
+  run:
+    name: Run make tidy
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version-file: go.mod
+
+    - name: Make tidy
+      run: make tidy
+    - name: Commit changes
+      run: |
+        # Exit early if there is nothing to commit. This can happen if someone pushes to the dependabot's PR (for example has to adapt to a breaking change).
+        if [[ -z $(git status --porcelain) ]]; then
+          echo "Nothing to commit, working tree clean. Exiting..."
+          exit 0
+        fi
+        
+        git config user.name gardener-robot-ci-1
+        git config user.email gardener.ci.user@gmail.com
+        git add .
+        git commit -m "[dependabot skip] make tidy"
+        git push origin


### PR DESCRIPTION
**What this PR does / why we need it**:
This should handle updates like https://github.com/gardener/gardener-discovery-server/pull/54
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
