### PR TITLE
[GEP-26] Serve workload identity discovery documents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ start:
 .PHONY: install
 install:
 	@LD_FLAGS=$(LD_FLAGS) EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) \
-	bash $(GARDENER_HACK_DIR)/install.sh ./...
+		bash $(GARDENER_HACK_DIR)/install.sh ./...
 
 
 .PHONY: docker-images

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![REUSE status](https://api.reuse.software/badge/github.com/gardener/gardener-discovery-server)](https://api.reuse.software/info/github.com/gardener/gardener-discovery-server)
 
-A server capable of serving public metadata about different Gardener resources like shoot OIDC discovery documents.
+A server capable of serving public metadata about different Gardener resources like shoot OIDC discovery documents and Gardener Workload Identity discovery.
 
 ## Development
 

--- a/charts/discovery-server/charts/runtime/templates/configmap-workload-identity.yaml
+++ b/charts/discovery-server/charts/runtime/templates/configmap-workload-identity.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if (and .Values.workloadIdentity.openIDConfig .Values.workloadIdentity.jwks) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "name" . }}-workload-identity
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "labels" . | indent 4 }}
+data:
+  openid-configuration.json: {{ required ".Values.workloadIdentity.openIDConfig is required" .Values.workloadIdentity.openIDConfig }}
+  jwks.json: {{ required ".Values.workloadIdentity.jwks is required" .Values.workloadIdentity.jwks }}
+{{- end }}

--- a/charts/discovery-server/charts/runtime/templates/deployment.yaml
+++ b/charts/discovery-server/charts/runtime/templates/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         {{- if .Values.kubeconfig }}
         checksum/gardener-discovery-server-kubeconfig: {{ include (print $.Template.BasePath "/secret-kubeconfig.yaml") . | sha256sum }}
         {{- end }}
+        {{- if (and .Values.workloadIdentity.openIDConfig .Values.workloadIdentity.jwks) }}
+        checksum/gardener-discovery-server-workload-identity: {{ include (print $.Template.BasePath "/configmap-workload-identity.yaml") . | sha256sum }}
+        {{- end }}
       labels:
         networking.gardener.cloud/to-dns: allowed
         {{- if .Values.global.virtualGarden.enabled }}
@@ -54,6 +57,10 @@ spec:
         {{- end }}
         - --tls-cert-file=/var/run/secrets/gardener.cloud/gardener-discovery-server/tls/tls.crt
         - --tls-private-key-file=/var/run/secrets/gardener.cloud/gardener-discovery-server/tls/tls.key
+        {{- if (and .Values.workloadIdentity.openIDConfig .Values.workloadIdentity.jwks) }}
+        - --workload-identity-openid-config-file=/etc/gardener-discovery-server/workload-identity/openid-configuration.json
+        - --workload-identity-jwks-file=/etc/gardener-discovery-server/workload-identity/jwks.json
+        {{- end}}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -101,6 +108,10 @@ spec:
           mountPath: {{ required ".Values.projectedKubeconfig.baseMountPath is required" .Values.projectedKubeconfig.baseMountPath }}
           readOnly: true
         {{- end }}
+        {{- if (and .Values.workloadIdentity.openIDConfig .Values.workloadIdentity.jwks) }}
+        - name: workload-identity
+          mountPath: /etc/gardener-discovery-server/workload-identity
+        {{- end }}
       volumes:
       - name: {{ include "name" . }}-tls
         secret:
@@ -128,4 +139,9 @@ spec:
                 path: token
               name: {{ required ".Values.projectedKubeconfig.tokenSecretName is required" .Values.projectedKubeconfig.tokenSecretName }}
               optional: false
+      {{- end }}
+      {{- if (and .Values.workloadIdentity.openIDConfig .Values.workloadIdentity.jwks) }}
+      - name: workload-identity
+        configMap:
+          configMapName: {{ include "name" . }}-workload-identity
       {{- end }}

--- a/charts/discovery-server/charts/runtime/templates/deployment.yaml
+++ b/charts/discovery-server/charts/runtime/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
         - --tls-cert-file=/var/run/secrets/gardener.cloud/gardener-discovery-server/tls/tls.crt
         - --tls-private-key-file=/var/run/secrets/gardener.cloud/gardener-discovery-server/tls/tls.key
         {{- if (and .Values.workloadIdentity.openIDConfig .Values.workloadIdentity.jwks) }}
-        - --workload-identity-openid-config-file=/etc/gardener-discovery-server/workload-identity/openid-configuration.json
+        - --workload-identity-openid-configuration-file=/etc/gardener-discovery-server/workload-identity/openid-configuration.json
         - --workload-identity-jwks-file=/etc/gardener-discovery-server/workload-identity/jwks.json
         {{- end}}
         livenessProbe:

--- a/charts/discovery-server/charts/runtime/values.yaml
+++ b/charts/discovery-server/charts/runtime/values.yaml
@@ -39,3 +39,7 @@ kubeconfig:
 #   baseMountPath: /var/run/secrets/gardener.cloud
 #   genericKubeconfigSecretName: generic-token-kubeconfig
 #   tokenSecretName: access-shoot-gardener-discovery-server
+
+workloadIdentity:
+  openIDConfig:
+  jwks:

--- a/cmd/discovery-server/app/app.go
+++ b/cmd/discovery-server/app/app.go
@@ -152,7 +152,7 @@ func run(ctx context.Context, log logr.Logger, conf *options.Config) error {
 	if conf.WorkloadIdentity.Enabled {
 		gardenHandler, err := workloadidentity.New(conf.WorkloadIdentity.OpenIDConfig, conf.WorkloadIdentity.JWKS, log.WithName("workload-identity"))
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to create workload identity handler, %w", err)
 		}
 		log.Info("Workload identity handler paths", "well-known", conf.WorkloadIdentity.OpenIDConfigPath, "jwks", conf.WorkloadIdentity.JWKSPath)
 

--- a/cmd/discovery-server/app/app.go
+++ b/cmd/discovery-server/app/app.go
@@ -152,7 +152,7 @@ func run(ctx context.Context, log logr.Logger, conf *options.Config) error {
 	if conf.WorkloadIdentity.Enabled {
 		gardenHandler, err := workloadidentity.New(conf.WorkloadIdentity.OpenIDConfig, conf.WorkloadIdentity.JWKS, log.WithName("workload-identity"))
 		if err != nil {
-			return fmt.Errorf("failed to create workload identity handler, %w", err)
+			return fmt.Errorf("failed to create workload identity handler: %w", err)
 		}
 		log.Info("Workload identity handler paths", "well-known", conf.WorkloadIdentity.OpenIDConfigPath, "jwks", conf.WorkloadIdentity.JWKSPath)
 

--- a/cmd/discovery-server/app/app.go
+++ b/cmd/discovery-server/app/app.go
@@ -150,19 +150,22 @@ func run(ctx context.Context, log logr.Logger, conf *options.Config) error {
 	)
 
 	if conf.WorkloadIdentity.Enabled {
+		const (
+			workloadIdentityOpenIDConfigPath = "/garden/workload-identity/issuer/.well-known/openid-configuration"
+			workloadIdentityJWKSPath         = "/garden/workload-identity/issuer/jwks"
+		)
 		gardenHandler, err := workloadidentity.New(conf.WorkloadIdentity.OpenIDConfig, conf.WorkloadIdentity.JWKS, log.WithName("workload-identity"))
 		if err != nil {
 			return fmt.Errorf("failed to create workload identity handler: %w", err)
 		}
-		log.Info("Workload identity handler paths", "well-known", conf.WorkloadIdentity.OpenIDConfigPath, "jwks", conf.WorkloadIdentity.JWKSPath)
 
 		mux.Handle(
-			conf.WorkloadIdentity.OpenIDConfigPath,
-			metrics.InstrumentHandler(conf.WorkloadIdentity.OpenIDConfigPath, http.HandlerFunc(gardenHandler.HandleWellKnown)),
+			workloadIdentityOpenIDConfigPath,
+			metrics.InstrumentHandler(workloadIdentityOpenIDConfigPath, http.HandlerFunc(gardenHandler.HandleWellKnown)),
 		)
 		mux.Handle(
-			conf.WorkloadIdentity.JWKSPath,
-			metrics.InstrumentHandler(conf.WorkloadIdentity.JWKSPath, http.HandlerFunc(gardenHandler.HandleJWKS)),
+			workloadIdentityJWKSPath,
+			metrics.InstrumentHandler(workloadIdentityJWKSPath, http.HandlerFunc(gardenHandler.HandleJWKS)),
 		)
 	}
 

--- a/cmd/discovery-server/app/app.go
+++ b/cmd/discovery-server/app/app.go
@@ -143,7 +143,7 @@ func run(ctx context.Context, log logr.Logger, conf *options.Config) error {
 	)
 	mux.Handle(
 		oidConfigPath,
-		metrics.InstrumentHandler(oidConfigPath, h.HandleWellKnown()),
+		metrics.InstrumentHandler(oidConfigPath, h.HandleOpenIDConfiguration()),
 	)
 	mux.Handle(
 		jwksPath,
@@ -162,7 +162,7 @@ func run(ctx context.Context, log logr.Logger, conf *options.Config) error {
 
 		mux.Handle(
 			workloadIdentityOpenIDConfigPath,
-			metrics.InstrumentHandler(workloadIdentityOpenIDConfigPath, workloadIdentityHandler.HandleWellKnown()),
+			metrics.InstrumentHandler(workloadIdentityOpenIDConfigPath, workloadIdentityHandler.HandleOpenIDConfiguration()),
 		)
 		mux.Handle(
 			workloadIdentityJWKSPath,
@@ -170,7 +170,7 @@ func run(ctx context.Context, log logr.Logger, conf *options.Config) error {
 		)
 	}
 
-	mux.Handle("/", handler.HandleNotFound(log))
+	mux.Handle("/", handler.SetHSTS(handler.NotFound(log)))
 
 	cert, err := dynamiccert.New(
 		conf.Serving.TLSCertFile,

--- a/cmd/discovery-server/app/options/options.go
+++ b/cmd/discovery-server/app/options/options.go
@@ -5,7 +5,6 @@
 package options
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -17,6 +16,8 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+
+	"github.com/gardener/gardener-discovery-server/internal/utils"
 )
 
 // Options contain the server options.
@@ -134,14 +135,9 @@ func (o *WorkloadIdentityOptions) ApplyTo(c *WorkloadIdentityConfig) error {
 		return err
 	}
 
-	type config struct {
-		Issuer  string `json:"issuer"`
-		JWKSURI string `json:"jwks_uri"`
-	}
-
-	conf := &config{}
-	if err := json.Unmarshal(c.OpenIDConfig, conf); err != nil {
-		return fmt.Errorf("failed to unmarshal openid configuration, %w", err)
+	conf, err := utils.LoadOpenIDConfig(c.OpenIDConfig)
+	if err != nil {
+		return err
 	}
 
 	issuerURL, err := url.Parse(conf.Issuer)

--- a/cmd/discovery-server/app/options/options.go
+++ b/cmd/discovery-server/app/options/options.go
@@ -142,13 +142,13 @@ func (o *WorkloadIdentityOptions) ApplyTo(c *WorkloadIdentityConfig) error {
 
 	issuerURL, err := url.Parse(conf.Issuer)
 	if err != nil {
-		return fmt.Errorf("failed to parse the issuer URL, %w", err)
+		return fmt.Errorf("failed to parse the issuer URL: %w", err)
 	}
 	c.OpenIDConfigPath = issuerURL.EscapedPath() + "/.well-known/openid-configuration"
 
 	jwksURI, err := url.Parse(conf.JWKSURI)
 	if err != nil {
-		return fmt.Errorf("failed to parse JWKS URI, %w", err)
+		return fmt.Errorf("failed to parse JWKS URI: %w", err)
 	}
 	c.JWKSPath = jwksURI.EscapedPath()
 

--- a/cmd/discovery-server/app/options/options.go
+++ b/cmd/discovery-server/app/options/options.go
@@ -22,9 +22,9 @@ import (
 
 // Options contain the server options.
 type Options struct {
-	ResyncOptions  ResyncOptions
-	ServingOptions ServingOptions
-	GardenOptions  WorkloadIdentityOptions
+	ResyncOptions           ResyncOptions
+	ServingOptions          ServingOptions
+	WorkloadIdentityOptions WorkloadIdentityOptions
 }
 
 // ServingOptions are options applied to the discovery server.
@@ -197,7 +197,7 @@ func NewOptions() *Options {
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	o.ServingOptions.AddFlags(fs)
 	o.ResyncOptions.AddFlags(fs)
-	o.GardenOptions.AddFlags(fs)
+	o.WorkloadIdentityOptions.AddFlags(fs)
 }
 
 // ApplyTo applies the options to the configuration.
@@ -206,7 +206,7 @@ func (o *Options) ApplyTo(server *Config) error {
 		return err
 	}
 
-	if err := o.GardenOptions.ApplyTo(&server.WorkloadIdentity); err != nil {
+	if err := o.WorkloadIdentityOptions.ApplyTo(&server.WorkloadIdentity); err != nil {
 		return err
 	}
 
@@ -218,7 +218,7 @@ func (o *Options) Validate() []error {
 	return slices.Concat(
 		o.ResyncOptions.Validate(),
 		o.ServingOptions.Validate(),
-		o.GardenOptions.Validate(),
+		o.WorkloadIdentityOptions.Validate(),
 	)
 }
 

--- a/cmd/discovery-server/app/options/options.go
+++ b/cmd/discovery-server/app/options/options.go
@@ -6,9 +6,7 @@ package options
 
 import (
 	"errors"
-	"fmt"
 	"net"
-	"net/url"
 	"os"
 	"slices"
 	"strconv"
@@ -16,8 +14,6 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
-
-	"github.com/gardener/gardener-discovery-server/internal/utils"
 )
 
 // Options contain the server options.
@@ -82,10 +78,6 @@ type WorkloadIdentityConfig struct {
 	OpenIDConfig []byte
 	// JWKS is the workload identity JWKS.
 	JWKS []byte
-	// OpenIDConfigPath is the http path the discovery server makes available the workload identity openid configuration document.
-	OpenIDConfigPath string
-	// JWKSPath is the http path the discovery server makes available the workload identity JWKS document.
-	JWKSPath string
 	// Enabled indicate whether the discovery server should serve workload identity discovery documents or not.
 	Enabled bool
 }
@@ -134,23 +126,6 @@ func (o *WorkloadIdentityOptions) ApplyTo(c *WorkloadIdentityConfig) error {
 	if err != nil {
 		return err
 	}
-
-	conf, err := utils.LoadOpenIDConfig(c.OpenIDConfig)
-	if err != nil {
-		return err
-	}
-
-	issuerURL, err := url.Parse(conf.Issuer)
-	if err != nil {
-		return fmt.Errorf("failed to parse the issuer URL: %w", err)
-	}
-	c.OpenIDConfigPath = issuerURL.EscapedPath() + "/.well-known/openid-configuration"
-
-	jwksURI, err := url.Parse(conf.JWKSURI)
-	if err != nil {
-		return fmt.Errorf("failed to parse JWKS URI: %w", err)
-	}
-	c.JWKSPath = jwksURI.EscapedPath()
 
 	return nil
 }

--- a/cmd/discovery-server/app/options/options.go
+++ b/cmd/discovery-server/app/options/options.go
@@ -84,7 +84,7 @@ type WorkloadIdentityConfig struct {
 
 // AddFlags adds workload identity options to  flagset
 func (o *WorkloadIdentityOptions) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&o.OpenIDConfigFile, "workload-identity-openid-config-file", o.OpenIDConfigFile, "Path to garden workload identity openid configuration file.")
+	fs.StringVar(&o.OpenIDConfigFile, "workload-identity-openid-configuration-file", o.OpenIDConfigFile, "Path to garden workload identity openid configuration file.")
 	fs.StringVar(&o.JWKSFile, "workload-identity-jwks-file", o.JWKSFile, "Path to garden workload identity JWKS file.")
 }
 
@@ -97,10 +97,10 @@ func (o *WorkloadIdentityOptions) Validate() []error {
 	}
 
 	if strings.TrimSpace(o.OpenIDConfigFile) == "" {
-		errs = append(errs, errors.New(`flag "workload-identity-openid-config-file" must be set when "workload-identity-jwks-file" is set`))
+		errs = append(errs, errors.New(`flag "workload-identity-openid-configuration-file" must be set when "workload-identity-jwks-file" is set`))
 	}
 	if strings.TrimSpace(o.JWKSFile) == "" {
-		errs = append(errs, errors.New(`flag "workload-identity-jwks-file" must be set when "workload-identity-openid-config-file" is set`))
+		errs = append(errs, errors.New(`flag "workload-identity-jwks-file" must be set when "workload-identity-openid-configuration-file" is set`))
 	}
 
 	return errs

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -33,7 +33,7 @@ func AllowMethods(next http.Handler, log logr.Logger, allowedMethods ...string) 
 		methods                  = sync.Map{}
 	)
 	for _, m := range allowedMethods {
-		methods.Store(m, struct{}{})
+		methods.Store(m, nil)
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if _, ok := methods.Load(r.Method); !ok {

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package handler
+
+import (
+	"net/http"
+	"slices"
+
+	"github.com/go-logr/logr"
+)
+
+const (
+	headerContentType = "Content-Type"
+	mimeAppJSON       = "application/json"
+)
+
+// SetHSTS is middleware handler setting Strict-Transport-Security header.
+func SetHSTS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if w.Header().Get("Strict-Transport-Security") == "" {
+			w.Header().Set("Strict-Transport-Security", "max-age=31536000")
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// AllowMethods is middleware handler restricting the allowed http methods.
+func AllowMethods(next http.Handler, log logr.Logger, allowedMethods ...string) http.Handler {
+	var responseMethodNotAllowed = []byte(`{"code":405,"message":"method not allowed"}`)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !slices.Contains(allowedMethods, r.Method) {
+			w.Header().Set(headerContentType, mimeAppJSON)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			if _, err := w.Write(responseMethodNotAllowed); err != nil {
+				log.Error(err, "Failed writing response")
+				return
+			}
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// HandleNotFound is handler replying with not found.
+func HandleNotFound(log logr.Logger) http.Handler {
+	var responseNotFound = []byte(`{"code":404,"message":"not found"}`)
+
+	return SetHSTS(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set(headerContentType, mimeAppJSON)
+			w.WriteHeader(http.StatusNotFound)
+			if _, err := w.Write(responseNotFound); err != nil {
+				log.Error(err, "Failed writing not found response")
+				return
+			}
+		}),
+	)
+}

--- a/internal/handler/handler_suite_test.go
+++ b/internal/handler/handler_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package handler_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHandler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Handler Test Suite")
+}

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -82,18 +82,17 @@ var _ = Describe("#Handler", func() {
 		})
 	})
 
-	Describe("#HandleNotFound", func() {
+	Describe("#NotFound", func() {
 		It("should return not found", func() {
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			resp := httptest.NewRecorder()
 
-			h := handler.HandleNotFound(log)
+			h := handler.NotFound(log)
 
 			h.ServeHTTP(resp, req)
 			Expect(resp).To(HaveHTTPStatus(http.StatusNotFound))
 			Expect(resp).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
 			Expect(resp).To(HaveHTTPBody(`{"code":404,"message":"not found"}`))
-			Expect(resp).To(HaveHTTPHeaderWithValue("Strict-Transport-Security", "max-age=31536000"))
 		})
 	})
 })

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package handler_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/gardener/gardener-discovery-server/internal/handler"
+)
+
+var _ = Describe("#Handler", func() {
+	var (
+		noOpHandler http.Handler
+		log         logr.Logger
+	)
+
+	BeforeEach(func() {
+		noOpHandler = http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
+		log = logzap.New(logzap.WriteTo(GinkgoWriter))
+	})
+
+	Describe("#SetHSTS", func() {
+		It("should set only HSTS headers", func() {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			resp := httptest.NewRecorder()
+
+			h := handler.SetHSTS(noOpHandler)
+
+			h.ServeHTTP(resp, req)
+			Expect(resp).To(HaveHTTPHeaderWithValue("Strict-Transport-Security", "max-age=31536000"))
+			Expect(resp.Header()).To(HaveLen(1))
+		})
+
+		It("should not overwrite already set HSTS headers", func() {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			resp := httptest.NewRecorder()
+
+			resp.Header().Set("Strict-Transport-Security", "max-age=1")
+
+			h := handler.SetHSTS(noOpHandler)
+
+			h.ServeHTTP(resp, req)
+			Expect(resp).To(HaveHTTPHeaderWithValue("Strict-Transport-Security", "max-age=1"))
+			Expect(resp.Header()).To(HaveLen(1))
+		})
+	})
+
+	Describe("#AllowMethods", func() {
+		It("should allow allowed methods", func() {
+			allowedMethods := []string{http.MethodGet, http.MethodConnect}
+			req := httptest.NewRequest(allowedMethods[0], "/", nil)
+			resp := httptest.NewRecorder()
+
+			h := handler.AllowMethods(noOpHandler, log, allowedMethods...)
+
+			h.ServeHTTP(resp, req)
+			Expect(resp).To(HaveHTTPStatus(http.StatusOK))
+			Expect(resp).To(HaveHTTPBody(""))
+			Expect(resp.Header()).To(HaveLen(0))
+		})
+
+		It("should disallow not allowed method", func() {
+			allowedMethods := []string{http.MethodGet, http.MethodPut}
+			disallowedMethod := http.MethodDelete
+			req := httptest.NewRequest(disallowedMethod, "/", nil)
+			resp := httptest.NewRecorder()
+
+			h := handler.AllowMethods(noOpHandler, log, allowedMethods...)
+
+			h.ServeHTTP(resp, req)
+			Expect(resp).To(HaveHTTPStatus(http.StatusMethodNotAllowed))
+			Expect(resp).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+			Expect(resp).To(HaveHTTPBody(`{"code":405,"message":"method not allowed"}`))
+		})
+	})
+
+	Describe("#HandleNotFound", func() {
+		It("should return not found", func() {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			resp := httptest.NewRecorder()
+
+			h := handler.HandleNotFound(log)
+
+			h.ServeHTTP(resp, req)
+			Expect(resp).To(HaveHTTPStatus(http.StatusNotFound))
+			Expect(resp).To(HaveHTTPHeaderWithValue("Content-Type", "application/json"))
+			Expect(resp).To(HaveHTTPBody(`{"code":404,"message":"not found"}`))
+			Expect(resp).To(HaveHTTPHeaderWithValue("Strict-Transport-Security", "max-age=31536000"))
+		})
+	})
+})

--- a/internal/handler/openidmeta/handler.go
+++ b/internal/handler/openidmeta/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 
+	"github.com/gardener/gardener-discovery-server/internal/handler"
 	store "github.com/gardener/gardener-discovery-server/internal/store/openidmeta"
 )
 
@@ -41,96 +42,54 @@ func New(store store.Reader, log logr.Logger) *Handler {
 
 // HandleWellKnown handles /.well-known/openid-configuration.
 // It requires "projectName" and "shootUID" as path parameters.
-func (h *Handler) HandleWellKnown(w http.ResponseWriter, r *http.Request) {
-	setHSTS(w)
-	if r.Method != http.MethodGet && r.Method != http.MethodHead {
-		w.Header().Set(headerContentType, mimeAppJSON)
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		if _, err := w.Write([]byte(responseMethodNotAllowed)); err != nil {
-			h.log.Error(err, "Failed writing response")
-			return
-		}
-		return
-	}
-
-	shootUID := r.PathValue("shootUID")
-	if _, err := uuid.Parse(shootUID); err != nil {
-		w.Header().Set(headerContentType, mimeAppJSON)
-		w.WriteHeader(http.StatusBadRequest)
-		if _, err := w.Write([]byte(responseBadRequest)); err != nil {
-			h.log.Error(err, "Failed writing response")
-			return
-		}
-		return
-	}
-
-	projectName := r.PathValue("projectName")
-	data, ok := h.store.Read(projectName + "--" + shootUID)
-	if !ok {
-		h.HandleNotFound(w, r)
-		return
-	}
-
-	w.Header().Set(headerCacheControl, pubCacheControl)
-	w.Header().Set(headerContentType, mimeAppJSON)
-	if _, err := w.Write(data.Config); err != nil {
-		h.log.Error(err, "Failed writing response")
-		return
-	}
+func (h *Handler) HandleWellKnown() http.Handler {
+	log := h.log.WithName("well-known")
+	return handler.SetHSTS(
+		handler.AllowMethods(handleRequest(log, h.store,
+			func(data store.Data) []byte { return data.Config },
+		),
+			log, http.MethodGet, http.MethodHead,
+		),
+	)
 }
 
 // HandleJWKS handles JWKS response.
 // It requires "projectName" and "shootUID" as path parameters.
-func (h *Handler) HandleJWKS(w http.ResponseWriter, r *http.Request) {
-	setHSTS(w)
-	if r.Method != http.MethodGet && r.Method != http.MethodHead {
-		w.Header().Set(headerContentType, mimeAppJSON)
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		if _, err := w.Write([]byte(responseMethodNotAllowed)); err != nil {
-			h.log.Error(err, "Failed writing response")
+func (h *Handler) HandleJWKS() http.Handler {
+	log := h.log.WithName("jwks")
+	return handler.SetHSTS(
+		handler.AllowMethods(handleRequest(log, h.store,
+			func(data store.Data) []byte { return data.JWKS },
+		),
+			log, http.MethodGet, http.MethodHead,
+		),
+	)
+}
+func handleRequest(log logr.Logger, s store.Reader, getContent func(store.Data) []byte) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		shootUID := r.PathValue("shootUID")
+		if _, err := uuid.Parse(shootUID); err != nil {
+			w.Header().Set(headerContentType, mimeAppJSON)
+			w.WriteHeader(http.StatusBadRequest)
+			if _, err := w.Write([]byte(responseBadRequest)); err != nil {
+				log.Error(err, "Failed writing bad request response")
+				return
+			}
 			return
 		}
-		return
-	}
-	shootUID := r.PathValue("shootUID")
-	if _, err := uuid.Parse(shootUID); err != nil {
-		w.Header().Set(headerContentType, mimeAppJSON)
-		w.WriteHeader(http.StatusBadRequest)
-		if _, err := w.Write([]byte(responseBadRequest)); err != nil {
-			h.log.Error(err, "Failed writing response")
+
+		projectName := r.PathValue("projectName")
+		data, ok := s.Read(projectName + "--" + shootUID)
+		if !ok {
+			handler.HandleNotFound(log).ServeHTTP(w, r)
 			return
 		}
-		return
-	}
 
-	projectName := r.PathValue("projectName")
-	data, ok := h.store.Read(projectName + "--" + shootUID)
-	if !ok {
-		h.HandleNotFound(w, r)
-		return
-	}
-
-	w.Header().Set(headerCacheControl, pubCacheControl)
-	w.Header().Set(headerContentType, mimeAppJSON)
-	if _, err := w.Write(data.JWKS); err != nil {
-		h.log.Error(err, "Failed writing response")
-		return
-	}
-}
-
-// HandleNotFound writes a not found response to writer.
-func (h *Handler) HandleNotFound(w http.ResponseWriter, _ *http.Request) {
-	setHSTS(w)
-	w.Header().Set(headerContentType, mimeAppJSON)
-	w.WriteHeader(http.StatusNotFound)
-	if _, err := w.Write([]byte(responseNotFound)); err != nil {
-		h.log.Error(err, "Failed writing response")
-		return
-	}
-}
-
-func setHSTS(w http.ResponseWriter) {
-	if w.Header().Get("Strict-Transport-Security") == "" {
-		w.Header().Set("Strict-Transport-Security", "max-age=31536000")
-	}
+		w.Header().Set(headerCacheControl, pubCacheControl)
+		w.Header().Set(headerContentType, mimeAppJSON)
+		if _, err := w.Write(getContent(data)); err != nil {
+			log.Error(err, "Failed writing response")
+			return
+		}
+	})
 }

--- a/internal/handler/openidmeta/handler_test.go
+++ b/internal/handler/openidmeta/handler_test.go
@@ -44,9 +44,9 @@ var _ = Describe("#HttpHandlerOpenIDMeta", func() {
 		log := logzap.New(logzap.WriteTo(GinkgoWriter))
 		oidHandler = oidhandler.New(store, log)
 		mux = http.NewServeMux()
-		mux.Handle("/projects/{projectName}/shoots/{shootUID}/issuer/.well-known/openid-configuration", oidHandler.HandleWellKnown())
+		mux.Handle("/projects/{projectName}/shoots/{shootUID}/issuer/.well-known/openid-configuration", oidHandler.HandleOpenIDConfiguration())
 		mux.Handle("/projects/{projectName}/shoots/{shootUID}/issuer/jwks", oidHandler.HandleJWKS())
-		mux.Handle("/", handler.HandleNotFound(log))
+		mux.Handle("/", handler.NotFound(log))
 	})
 
 	DescribeTable(
@@ -162,12 +162,11 @@ var _ = Describe("#HttpHandlerOpenIDMeta", func() {
 			404,
 			[]byte(`{"code":404,"message":"not found"}`),
 			map[string]string{
-				"Strict-Transport-Security": "max-age=31536000",
-				"Content-Type":              "application/json",
+				"Content-Type": "application/json",
 			},
 		),
 		Entry(
-			"should return method not allowed when querying the well-known endpoint with POST",
+			"should return method not allowed when querying the openid-configuration endpoint with POST",
 			http.MethodPost,
 			"https://abc.def/projects/foo/shoots/1e4914ca-c837-451d-a1cf-c559d131cb57/issuer/.well-known/openid-configuration",
 			405,

--- a/internal/handler/workloadidentity/handler.go
+++ b/internal/handler/workloadidentity/handler.go
@@ -41,7 +41,7 @@ func New(openIDConfig, jwks []byte, logger logr.Logger) (*Handler, error) {
 
 	issuerURL, err := url.Parse(conf.Issuer)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse issuer url, %w", err)
+		return nil, fmt.Errorf("failed to parse issuer url: %w", err)
 	}
 	if issuerURL.Scheme != "https" {
 		return nil, errors.New("invalid issuer url scheme")
@@ -55,7 +55,7 @@ func New(openIDConfig, jwks []byte, logger logr.Logger) (*Handler, error) {
 
 	jwksURL, err := url.Parse(conf.JWKSURI)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse jwks url, %w", err)
+		return nil, fmt.Errorf("failed to parse jwks url: %w", err)
 	}
 	if jwksURL.Scheme != "https" {
 		return nil, errors.New("invalid jwks url scheme")

--- a/internal/handler/workloadidentity/handler.go
+++ b/internal/handler/workloadidentity/handler.go
@@ -94,7 +94,7 @@ func handleRequest(logger logr.Logger, responseData []byte, w http.ResponseWrite
 		w.Header().Set("Strict-Transport-Security", "max-age=31536000")
 	}
 
-	if isValid := handleInvalidRequest(logger.WithName("invalid-request-handler"), w, r); !isValid {
+	if isValid := handleInvalidRequest(logger, w, r); !isValid {
 		return
 	}
 
@@ -117,7 +117,7 @@ func handleInvalidRequest(logger logr.Logger, w http.ResponseWriter, r *http.Req
 	w.Header().Set(headerContentType, mimeAppJSON)
 	w.WriteHeader(http.StatusMethodNotAllowed)
 	if _, err := w.Write([]byte(responseMethodNotAllowed)); err != nil {
-		logger.Error(err, "Failed writing response")
+		logger.Error(err, "Failed writing method not allowed response")
 		return false
 	}
 	return false

--- a/internal/handler/workloadidentity/handler.go
+++ b/internal/handler/workloadidentity/handler.go
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package workloadidentity
+
+import (
+	"net/http"
+
+	"github.com/go-logr/logr"
+)
+
+const (
+	headerCacheControl = "Cache-Control"
+	pubCacheControl    = "public, max-age=3600"
+
+	headerContentType = "Content-Type"
+	mimeAppJSON       = "application/json"
+
+	responseMethodNotAllowed = `{"code":405,"message":"method not allowed"}`
+)
+
+// Handler implements handler functions for the openid configuration and JWKS endpoints.
+type Handler struct {
+	oidc []byte
+	jwks []byte
+	log  logr.Logger
+}
+
+// New creates new workload identity handler.
+func New(openIDConfig, jwks []byte, logger logr.Logger) (*Handler, error) {
+	return &Handler{
+		oidc: openIDConfig,
+		jwks: jwks,
+		log:  logger,
+	}, nil
+}
+
+// HandleWellKnown handles /.well-known/openid-configuration.
+func (h *Handler) HandleWellKnown(w http.ResponseWriter, r *http.Request) {
+	handleRequest(h.log.WithName("well-known"), h.oidc, w, r)
+}
+
+// HandleJWKS handles JWKS response.
+func (h *Handler) HandleJWKS(w http.ResponseWriter, r *http.Request) {
+	handleRequest(h.log.WithName("jwks"), h.jwks, w, r)
+}
+
+func handleRequest(logger logr.Logger, responseData []byte, w http.ResponseWriter, r *http.Request) {
+	if w.Header().Get("Strict-Transport-Security") == "" {
+		w.Header().Set("Strict-Transport-Security", "max-age=31536000")
+	}
+
+	if isValid := handleInvalidRequest(logger.WithName("invalid-request-handler"), w, r); !isValid {
+		return
+	}
+
+	w.Header().Set(headerCacheControl, pubCacheControl)
+	w.Header().Set(headerContentType, mimeAppJSON)
+
+	if _, err := w.Write(responseData); err != nil {
+		logger.Error(err, "Failed writing response")
+		return
+	}
+}
+
+// handleInvalidRequest handles invalid requests.
+// It returns true if the request is valid, and false otherwise.
+func handleInvalidRequest(logger logr.Logger, w http.ResponseWriter, r *http.Request) bool {
+	if r.Method == http.MethodGet || r.Method == http.MethodHead {
+		return true
+	}
+
+	w.Header().Set(headerContentType, mimeAppJSON)
+	w.WriteHeader(http.StatusMethodNotAllowed)
+	if _, err := w.Write([]byte(responseMethodNotAllowed)); err != nil {
+		logger.Error(err, "Failed writing response")
+		return false
+	}
+	return false
+}

--- a/internal/handler/workloadidentity/handler.go
+++ b/internal/handler/workloadidentity/handler.go
@@ -5,9 +5,14 @@
 package workloadidentity
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/go-logr/logr"
+
+	"github.com/gardener/gardener-discovery-server/internal/utils"
 )
 
 const (
@@ -29,6 +34,44 @@ type Handler struct {
 
 // New creates new workload identity handler.
 func New(openIDConfig, jwks []byte, logger logr.Logger) (*Handler, error) {
+	conf, err := utils.LoadOpenIDConfig(openIDConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load openid configuration: %w", err)
+	}
+
+	issuerURL, err := url.Parse(conf.Issuer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse issuer url, %w", err)
+	}
+	if issuerURL.Scheme != "https" {
+		return nil, errors.New("invalid issuer url scheme")
+	}
+	if issuerURL.RawQuery != "" {
+		return nil, errors.New("issuer url must not contain query")
+	}
+	if issuerURL.Fragment != "" {
+		return nil, errors.New("issuer url must not contain fragment")
+	}
+
+	jwksURL, err := url.Parse(conf.JWKSURI)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse jwks url, %w", err)
+	}
+	if jwksURL.Scheme != "https" {
+		return nil, errors.New("invalid jwks url scheme")
+	}
+
+	keySet, err := utils.LoadKeySet(jwks)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load json web key set: %w", err)
+	}
+
+	for _, k := range keySet.Keys {
+		if !k.IsPublic() {
+			return nil, fmt.Errorf("jwks key with id %q is not public", k.KeyID)
+		}
+	}
+
 	return &Handler{
 		oidc: openIDConfig,
 		jwks: jwks,

--- a/internal/handler/workloadidentity/handler.go
+++ b/internal/handler/workloadidentity/handler.go
@@ -78,9 +78,9 @@ func New(openIDConfig, jwks []byte, logger logr.Logger) (*Handler, error) {
 	}, nil
 }
 
-// HandleWellKnown handles /.well-known/openid-configuration.
-func (h *Handler) HandleWellKnown() http.Handler {
-	log := h.log.WithName("well-known")
+// HandleOpenIDConfiguration handles /.well-known/openid-configuration.
+func (h *Handler) HandleOpenIDConfiguration() http.Handler {
+	log := h.log.WithName("openid-configuration")
 	return handler.SetHSTS(
 		handler.AllowMethods(handleRequest(log, h.oidc),
 			log, http.MethodGet, http.MethodHead,

--- a/internal/handler/workloadidentity/handler_suite_test.go
+++ b/internal/handler/workloadidentity/handler_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package workloadidentity_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestOpenIDMeta(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Workload Identity Handler Test Suite")
+}

--- a/internal/handler/workloadidentity/handler_test.go
+++ b/internal/handler/workloadidentity/handler_test.go
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package workloadidentity_test
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	"k8s.io/utils/ptr"
+	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/gardener/gardener-discovery-server/internal/handler/workloadidentity"
+	"github.com/gardener/gardener-discovery-server/internal/utils"
+)
+
+var _ = Describe("#WorkloadIdentity", func() {
+	const pathPrefix = "/garden/workload-identity/issuer"
+	var (
+		openIDConfig []byte
+		jwks         []byte
+		handler      *workloadidentity.Handler
+		mux          *http.ServeMux
+		logger       logr.Logger
+
+		headers map[string]string
+	)
+
+	BeforeEach(func() {
+		logger = logzap.New(logzap.WriteTo(GinkgoWriter))
+		var (
+			iss = "https://test.discovery-server.gardener.cloud.local" + pathPrefix
+			err error
+		)
+
+		openIDConfig, err = createOpenIDMeta(iss, iss+"/jwks")
+		Expect(err).ToNot(HaveOccurred())
+
+		privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		Expect(err).ToNot(HaveOccurred())
+
+		publicKey := privateKey.Public()
+		kid, err := getKeyID(publicKey)
+		Expect(err).ToNot(HaveOccurred())
+
+		jwks, err = createJWKS(publicKey, kid)
+		Expect(err).ToNot(HaveOccurred())
+
+		handler, err = workloadidentity.New(openIDConfig, jwks, logger)
+		Expect(err).ToNot(HaveOccurred())
+
+		mux = http.NewServeMux()
+		mux.HandleFunc(pathPrefix+"/.well-known/openid-configuration", handler.HandleWellKnown)
+		mux.HandleFunc(pathPrefix+"/jwks", handler.HandleJWKS)
+
+		headers = map[string]string{
+			"Strict-Transport-Security": "max-age=31536000",
+			"Content-Type":              "application/json",
+			"Cache-Control":             "public, max-age=3600",
+		}
+	})
+
+	Describe("#New", func() {
+		DescribeTable("Issuer url",
+			func(iss string, matcher types.GomegaMatcher) {
+				openIDConfig, err := createOpenIDMeta(iss, iss+"/jwks")
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = workloadidentity.New(openIDConfig, jwks, logger)
+				Expect(err).To(matcher)
+			},
+			Entry("should not allow issuer url with control characters", "https://foo.\n.bar", MatchError(ContainSubstring("failed to parse issuer url"))),
+			Entry("should not allow issuer url using scheme other than https", "ftp://foo.bar", MatchError("invalid issuer url scheme")),
+			Entry("should not allow issuer url using query", "https://foo.bar/?baz=42", MatchError("issuer url must not contain query")),
+			Entry("should not allow issuer url using fragment", "https://foo.bar/#baz", MatchError("issuer url must not contain fragment")),
+			Entry("should allow valid issuer url", "https://foo.bar/issuer", Not(HaveOccurred())),
+		)
+
+		DescribeTable("JWKS URL",
+			func(jwkURL string, matcher types.GomegaMatcher) {
+				openIDConfig, err := createOpenIDMeta("https://foo.bar", jwkURL)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = workloadidentity.New(openIDConfig, jwks, logger)
+				Expect(err).To(matcher)
+			},
+			Entry("should not allow jwks url with control characters", "https://foo.\n.bar/jwks", MatchError(ContainSubstring("failed to parse jwks url"))),
+			Entry("should not allow jwks url using scheme other than https", "ftp://foo.bar/jwks", MatchError("invalid jwks url scheme")),
+			Entry("should allow valid jwks url", "https://foo.bar/jwks", Not(HaveOccurred())),
+		)
+
+		It("should fail to create new handler when the there is a non-public JWK in the key set", func() {
+			privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).ToNot(HaveOccurred())
+
+			kid := "id-test"
+			jwks, err := createJWKS(privateKey, kid)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = workloadidentity.New(openIDConfig, jwks, logger)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Errorf("jwks key with id %q is not public", kid)))
+		})
+
+		It("should fail to load openid configuration", func() {
+			_, err := workloadidentity.New([]byte(`invalid openid configuration}`), jwks, logger)
+			Expect(err).To(MatchError(ContainSubstring("failed to load openid configuration")))
+		})
+
+		It("should fail to load json web key set", func() {
+			_, err := workloadidentity.New(openIDConfig, []byte(`invalid json web key set}`), logger)
+			Expect(err).To(MatchError(ContainSubstring("failed to load json web key set")))
+		})
+	})
+
+	DescribeTable("#handleRequest",
+		func(method, path string, expectedStatus int, expectedResponse *[]byte, expectedHeaders map[string]string) {
+			request := httptest.NewRequest(method, path, nil)
+			recorder := httptest.NewRecorder()
+			mux.ServeHTTP(recorder, request)
+
+			Expect(recorder).To(HaveHTTPStatus(expectedStatus))
+			Expect(recorder).To(HaveHTTPBody(string(*expectedResponse)))
+			for k, v := range expectedHeaders {
+				Expect(recorder).To(HaveHTTPHeaderWithValue(k, v))
+			}
+		},
+		Entry("[OpenIDConfiguration] it should successfully get document",
+			http.MethodGet, pathPrefix+"/.well-known/openid-configuration", http.StatusOK, &openIDConfig, headers),
+		Entry("[OpenIDConfiguration] it should successfully head document",
+			http.MethodHead, pathPrefix+"/.well-known/openid-configuration", http.StatusOK, &openIDConfig, headers),
+		Entry("[OpenIDConfiguration] it should fail post document",
+			http.MethodPost, pathPrefix+"/.well-known/openid-configuration", http.StatusMethodNotAllowed, ptr.To([]byte(`{"code":405,"message":"method not allowed"}`)), headers),
+		Entry("[JWKS] it should successfully get document",
+			http.MethodGet, pathPrefix+"/jwks", http.StatusOK, &jwks, headers),
+		Entry("[JWKS] it should successfully head document",
+			http.MethodHead, pathPrefix+"/jwks", http.StatusOK, &jwks, headers),
+		Entry("[JWKS] it should fail post document",
+			http.MethodPost, pathPrefix+"/jwks", http.StatusMethodNotAllowed, ptr.To([]byte(`{"code":405,"message":"method not allowed"}`)), headers),
+		Entry("it should return not found on other paths",
+			http.MethodGet, pathPrefix, http.StatusNotFound, ptr.To([]byte("404 page not found\n")), nil),
+	)
+})
+
+func getKeyID(publicKey crypto.PublicKey) (string, error) {
+	marshaled, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		return "", err
+	}
+	shaSum := sha256.Sum256(marshaled)
+	return base64.RawURLEncoding.EncodeToString(shaSum[:]), nil
+}
+
+func createOpenIDMeta(iss, jwks string) ([]byte, error) {
+	openIDMetadata := utils.OpenIDMetadata{
+		Issuer:  iss,
+		JWKSURI: jwks,
+	}
+	return json.Marshal(openIDMetadata)
+}
+
+func createJWKS(key any, kid string) ([]byte, error) {
+	keySet := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{{
+			Algorithm: string(jose.RS256),
+			Key:       key,
+			Use:       "sig",
+			KeyID:     kid,
+		}},
+	}
+	return json.Marshal(keySet)
+}

--- a/internal/handler/workloadidentity/handler_test.go
+++ b/internal/handler/workloadidentity/handler_test.go
@@ -64,8 +64,8 @@ var _ = Describe("#WorkloadIdentity", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		mux = http.NewServeMux()
-		mux.HandleFunc(pathPrefix+"/.well-known/openid-configuration", handler.HandleWellKnown)
-		mux.HandleFunc(pathPrefix+"/jwks", handler.HandleJWKS)
+		mux.Handle(pathPrefix+"/.well-known/openid-configuration", handler.HandleWellKnown())
+		mux.Handle(pathPrefix+"/jwks", handler.HandleJWKS())
 
 		headers = map[string]string{
 			"Strict-Transport-Security": "max-age=31536000",

--- a/internal/handler/workloadidentity/handler_test.go
+++ b/internal/handler/workloadidentity/handler_test.go
@@ -64,7 +64,7 @@ var _ = Describe("#WorkloadIdentity", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		mux = http.NewServeMux()
-		mux.Handle(pathPrefix+"/.well-known/openid-configuration", handler.HandleWellKnown())
+		mux.Handle(pathPrefix+"/.well-known/openid-configuration", handler.HandleOpenIDConfiguration())
 		mux.Handle(pathPrefix+"/jwks", handler.HandleJWKS())
 
 		headers = map[string]string{

--- a/internal/reconciler/openidmeta/metadata_test.go
+++ b/internal/reconciler/openidmeta/metadata_test.go
@@ -32,6 +32,7 @@ import (
 
 	oidreconciler "github.com/gardener/gardener-discovery-server/internal/reconciler/openidmeta"
 	oidstore "github.com/gardener/gardener-discovery-server/internal/store/openidmeta"
+	"github.com/gardener/gardener-discovery-server/internal/utils"
 )
 
 var _ = Describe("#ReconcileOpenIDMeta", func() {
@@ -258,8 +259,7 @@ var _ = Describe("#ReconcileOpenIDMeta", func() {
 			kid := base64.URLEncoding.EncodeToString(thumb)
 			privateKey.KeyID = kid
 
-			keySet := &jose.JSONWebKeySet{}
-			err = json.Unmarshal(secret.Data["jwks"], keySet)
+			keySet, err := utils.LoadKeySet(secret.Data["jwks"])
 			Expect(err).ToNot(HaveOccurred())
 			keySet.Keys = append(keySet.Keys, privateKey)
 
@@ -270,8 +270,7 @@ var _ = Describe("#ReconcileOpenIDMeta", func() {
 			Expect(c.Update(ctx, secret)).To(Succeed())
 		}),
 		Entry("jwks contains an invalid key", func() {
-			keySet := &jose.JSONWebKeySet{}
-			err := json.Unmarshal(secret.Data["jwks"], keySet)
+			keySet, err := utils.LoadKeySet(secret.Data["jwks"])
 			Expect(err).ToNot(HaveOccurred())
 
 			// this key will not be unmarshaled successfully

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -30,7 +30,7 @@ func SplitProjectNameAndShootUID(key string) (string, string, error) {
 func LoadKeySet(jwks []byte) (*jose.JSONWebKeySet, error) {
 	keySet := &jose.JSONWebKeySet{}
 	if err := json.Unmarshal(jwks, &keySet); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal JWKs, %w", err)
+		return nil, fmt.Errorf("failed to unmarshal JWKS: %w", err)
 	}
 
 	return keySet, nil
@@ -47,7 +47,7 @@ type OpenIDMetadata struct {
 func LoadOpenIDConfig(config []byte) (*OpenIDMetadata, error) {
 	openIDConfig := &OpenIDMetadata{}
 	if err := json.Unmarshal(config, openIDConfig); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal openid configuration, %w", err)
+		return nil, fmt.Errorf("failed to unmarshal openid configuration: %w", err)
 	}
 	return openIDConfig, nil
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -5,8 +5,12 @@
 package utils
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
+
+	"github.com/go-jose/go-jose/v4"
 )
 
 // ErrProjShootUIDInvalidFormat is an error that is returned if
@@ -20,4 +24,30 @@ func SplitProjectNameAndShootUID(key string) (string, string, error) {
 		return "", "", ErrProjShootUIDInvalidFormat
 	}
 	return split[0], split[1], nil
+}
+
+// LoadKeySet parses the jwks key set.
+func LoadKeySet(jwks []byte) (*jose.JSONWebKeySet, error) {
+	keySet := &jose.JSONWebKeySet{}
+	if err := json.Unmarshal(jwks, &keySet); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JWKs, %w", err)
+	}
+
+	return keySet, nil
+}
+
+// OpenIDMetadata is a minimal struct allowing to parse the issuer and jwks URIs
+// from the OIDC discovery page.
+type OpenIDMetadata struct {
+	Issuer  string `json:"issuer"`
+	JWKSURI string `json:"jwks_uri"`
+}
+
+// LoadOpenIDConfig parses the openid configuration page.
+func LoadOpenIDConfig(config []byte) (*OpenIDMetadata, error) {
+	openIDConfig := &OpenIDMetadata{}
+	if err := json.Unmarshal(config, openIDConfig); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal openid configuration, %w", err)
+	}
+	return openIDConfig, nil
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Utils", func() {
 			rawJWKS := []byte(`invalid jwks`)
 
 			_, err := utils.LoadKeySet(rawJWKS)
-			Expect(err).To(MatchError(ContainSubstring("failed to unmarshal JWKs")))
+			Expect(err).To(MatchError(ContainSubstring("failed to unmarshal JWKS")))
 		})
 
 	})

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -41,4 +41,69 @@ var _ = Describe("Utils", func() {
 			Entry("too many arguments to split", "a--b--c"),
 		)
 	})
+
+	Describe("#LoadOpenIDConfig", func() {
+		It("should successfully load openid configuration", func() {
+			rawOpenIDConfig := []byte(`{
+    "issuer": "https://test.discovery-server.gardener.cloud/issuer",
+    "jwks_uri": "https://test.discovery-server.gardener.cloud/issuer/jwks",
+    "response_types_supported": [
+        "id_token"
+    ],
+    "subject_types_supported": [
+        "public"
+    ],
+    "id_token_signing_alg_values_supported": [
+        "RS256"
+    ]
+}`)
+			config, err := utils.LoadOpenIDConfig(rawOpenIDConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Issuer).To(Equal("https://test.discovery-server.gardener.cloud/issuer"))
+			Expect(config.JWKSURI).To(Equal("https://test.discovery-server.gardener.cloud/issuer/jwks"))
+		})
+
+		It("should fail to load invalid openid configuration", func() {
+			invalidConfig := []byte(`invalid config`)
+			_, err := utils.LoadOpenIDConfig(invalidConfig)
+			Expect(err).To(MatchError(ContainSubstring("failed to unmarshal openid configuration")))
+		})
+	})
+
+	Describe("#LoadKeySet", func() {
+		It("should successfully load JSON Web Key Set", func() {
+			rawJWKS := []byte(`{
+    "keys": [
+        {
+            "use": "sig",
+            "kty": "RSA",
+            "kid": "2qAiW7sYZexfKki3E3E_sU9y2Hvgy7RJzoqMZueTOII",
+            "alg": "RS256",
+            "n": "2oJH7dZhbIjjSDjGR69v1aC1S-mZ3LSkNgXrVpngkpZLvNJaxxDUCbrQR7nBHamOwDHBXDRq_GbU5H8ZEG8P_9TjhKHVDr6PwzahJNoXliegQlVXurtcbzrWrYoJy30fw-rWPhyjQhadLiEChtx6a9BpMek1WicfwzGXAVjQip06U8tUTN9KxMhDYIRAd0FJgu-IRhsDImHwoGP2JsqsvSndE6Dw5vc-mo8koZR_2I14Qd8zeq3mBBsRi6JRl3Y0qOjPQCFrQAPt6LnGHkCFiQmqsKozBZbeWmRZbIhA-1sHsx9Qs5TtzUaXYHz9oIpT02-rQXqRxxCaDrTl2OsImQ",
+            "e": "AQAB"
+        }
+    ]
+}`)
+
+			jwks, err := utils.LoadKeySet(rawJWKS)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(jwks.Keys).To(HaveLen(1))
+
+			jwk := jwks.Key("2qAiW7sYZexfKki3E3E_sU9y2Hvgy7RJzoqMZueTOII")
+			Expect(jwk).To(HaveLen(1))
+			Expect(jwk[0].Algorithm).To(Equal("RS256"))
+			Expect(jwk[0].KeyID).To(Equal("2qAiW7sYZexfKki3E3E_sU9y2Hvgy7RJzoqMZueTOII"))
+			Expect(jwk[0].Use).To(Equal("sig"))
+			Expect(jwk[0].Valid()).To(BeTrue())
+			Expect(jwk[0].IsPublic()).To(BeTrue())
+		})
+
+		It("should fail to load invalid openid configuration", func() {
+			rawJWKS := []byte(`invalid jwks`)
+
+			_, err := utils.LoadKeySet(rawJWKS)
+			Expect(err).To(MatchError(ContainSubstring("failed to unmarshal JWKs")))
+		})
+
+	})
 })

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -13,6 +13,7 @@ build:
             - cmd/discovery-server/app
             - cmd/discovery-server/app/options
             - internal/dynamiccert
+            - internal/handler
             - internal/handler/openidmeta
             - internal/handler/workloadidentity
             - internal/metrics

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -14,6 +14,7 @@ build:
             - cmd/discovery-server/app/options
             - internal/dynamiccert
             - internal/handler/openidmeta
+            - internal/handler/workloadidentity
             - internal/metrics
             - internal/reconciler/openidmeta
             - internal/store/openidmeta

--- a/test/e2e/create_enable_delete_test.go
+++ b/test/e2e/create_enable_delete_test.go
@@ -14,11 +14,11 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-jose/go-jose/v4"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener-discovery-server/internal/utils"
 	"github.com/gardener/gardener/test/framework"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -78,8 +78,8 @@ var _ = Describe("Managed Issuer Tests", Label("ManagedIssuer"), func() {
 		resp.Body.Close()
 		Expect(err).ToNot(HaveOccurred())
 
-		keySet := jose.JSONWebKeySet{}
-		Expect(json.Unmarshal(jwks, &keySet)).To(Succeed())
+		keySet, err := utils.LoadKeySet(jwks)
+		Expect(err).ToNot(HaveOccurred())
 		Expect(keySet.Keys).To(HaveLen(1))
 		pubKey, ok := (keySet.Keys[0].Key).(*rsa.PublicKey)
 		Expect(ok).To(BeTrue())


### PR DESCRIPTION
**What this PR does / why we need it**:
Serve workload identity discovery documents

/area security ipcei
/kind enhancement
/label ipcei/workload-identity


**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Gardener discovery server now can serve the OIDC discovery documents of Gardener Workload Identity. 
The openid configuration and jwks content is configured via the flags `--workload-identity-openid-configuration-file` and `--workload-identity-jwks-file` respectively, the documents are served on the paths `/garden/workload-identity/issuer/.well-known/openid-configuration` and `/garden/workload-identity/issuer/jwks` . The feature is disabled when none of the flags is set. 
```
