### PR TITLE
Mount workload-identity files as readonly

### DIFF
--- a/charts/discovery-server/charts/runtime/templates/deployment.yaml
+++ b/charts/discovery-server/charts/runtime/templates/deployment.yaml
@@ -111,6 +111,7 @@ spec:
         {{- if (and .Values.workloadIdentity.openIDConfig .Values.workloadIdentity.jwks) }}
         - name: workload-identity
           mountPath: /etc/gardener-discovery-server/workload-identity
+          readOnly: true
         {{- end }}
       volumes:
       - name: {{ include "name" . }}-tls

--- a/charts/discovery-server/charts/runtime/templates/deployment.yaml
+++ b/charts/discovery-server/charts/runtime/templates/deployment.yaml
@@ -145,4 +145,5 @@ spec:
       - name: workload-identity
         configMap:
           configMapName: {{ include "name" . }}-workload-identity
+          defaultMode: 420
       {{- end }}

--- a/charts/discovery-server/charts/runtime/templates/deployment.yaml
+++ b/charts/discovery-server/charts/runtime/templates/deployment.yaml
@@ -144,6 +144,6 @@ spec:
       {{- if (and .Values.workloadIdentity.openIDConfig .Values.workloadIdentity.jwks) }}
       - name: workload-identity
         configMap:
-          configMapName: {{ include "name" . }}-workload-identity
+          name: {{ include "name" . }}-workload-identity
           defaultMode: 420
       {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Mounts the workload-identity files as readonly in helm chart definition.

/kind enhancement

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
