### PR TITLE
[GEP-26] Store workload identity documents in secret

### DIFF
--- a/charts/discovery-server/charts/runtime/templates/deployment.yaml
+++ b/charts/discovery-server/charts/runtime/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         checksum/gardener-discovery-server-kubeconfig: {{ include (print $.Template.BasePath "/secret-kubeconfig.yaml") . | sha256sum }}
         {{- end }}
         {{- if (and .Values.workloadIdentity.openIDConfig .Values.workloadIdentity.jwks) }}
-        checksum/gardener-discovery-server-workload-identity: {{ include (print $.Template.BasePath "/configmap-workload-identity.yaml") . | sha256sum }}
+        checksum/gardener-discovery-server-workload-identity: {{ include (print $.Template.BasePath "/secret-workload-identity.yaml") . | sha256sum }}
         {{- end }}
       labels:
         networking.gardener.cloud/to-dns: allowed
@@ -143,7 +143,7 @@ spec:
       {{- end }}
       {{- if (and .Values.workloadIdentity.openIDConfig .Values.workloadIdentity.jwks) }}
       - name: workload-identity
-        configMap:
-          name: {{ include "name" . }}-workload-identity
+        secret:
+          secretName: {{ include "name" . }}-workload-identity
           defaultMode: 420
       {{- end }}

--- a/charts/discovery-server/charts/runtime/templates/secret-workload-identity.yaml
+++ b/charts/discovery-server/charts/runtime/templates/secret-workload-identity.yaml
@@ -4,13 +4,14 @@
 
 {{- if (and .Values.workloadIdentity.openIDConfig .Values.workloadIdentity.jwks) }}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ include "name" . }}-workload-identity
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "labels" . | indent 4 }}
+type: Opaque
 data:
-  openid-configuration.json: {{ required ".Values.workloadIdentity.openIDConfig is required" .Values.workloadIdentity.openIDConfig }}
-  jwks.json: {{ required ".Values.workloadIdentity.jwks is required" .Values.workloadIdentity.jwks }}
+  openid-configuration.json: {{ required ".Values.workloadIdentity.openIDConfig is required" .Values.workloadIdentity.openIDConfig | b64enc }}
+  jwks.json: {{ required ".Values.workloadIdentity.jwks is required" .Values.workloadIdentity.jwks | b64enc }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Store workload identity documents in secret

**Which issue(s) this PR fixes**:
Part gardener/gardener#9586

/area security ipcei
/kind enhancement
/label ipcei/workload-identity

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
