### PR TITLE
Fix concurrent access to map

### DIFF
--- a/internal/reconciler/certificate/reconciler.go
+++ b/internal/reconciler/certificate/reconciler.go
@@ -32,7 +32,7 @@ import (
 type Reconciler struct {
 	once         sync.Once
 	storeMapping map[string]string
-	mutex        sync.RWMutex
+	mutex        sync.Mutex
 
 	Client       client.Client
 	ResyncPeriod time.Duration

--- a/internal/reconciler/certificate/reconciler.go
+++ b/internal/reconciler/certificate/reconciler.go
@@ -32,6 +32,7 @@ import (
 type Reconciler struct {
 	once         sync.Once
 	storeMapping map[string]string
+	mutex        sync.RWMutex
 
 	Client       client.Client
 	ResyncPeriod time.Duration
@@ -230,6 +231,9 @@ func (r *Reconciler) init() {
 }
 
 func (r *Reconciler) createMapping(mapKey, dataKey string, data []byte) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
 	r.storeMapping[mapKey] = dataKey
 	r.Store.Write(dataKey, certificate.Data{
 		CABundle: data,
@@ -237,6 +241,9 @@ func (r *Reconciler) createMapping(mapKey, dataKey string, data []byte) {
 }
 
 func (r *Reconciler) deleteMapping(key string) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
 	r.Store.Delete(r.storeMapping[key])
 	delete(r.storeMapping, key)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix concurrent access to map

**Which issue(s) this PR fixes**:
Fixes error like

```log
fatal error: concurrent map writes

goroutine 191 [running]:
github.com/gardener/gardener-discovery-server/internal/reconciler/certificate.(*Reconciler).createMapping(...)
	/go/src/github.com/gardener/gardener-discovery-server/internal/reconciler/certificate/reconciler.go:233
github.com/gardener/gardener-discovery-server/internal/reconciler/certificate.(*Reconciler).Reconcile(0xc000375f00, {0x2484fc8, 0xc001484fc0}, {{{0xc00037a640?, 0x213c574?}, {0xc0000612c0?, 0x100?}}})
	/go/src/github.com/gardener/gardener-discovery-server/internal/reconciler/certificate/reconciler.go:221 +0x2194
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile(0xc001484f30?, {0x2484fc8?, 0xc001484fc0?}, {{{0xc00037a640?, 0x0?}, {0xc0000612c0?, 0x0?}}})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.4/pkg/internal/controller/controller.go:116 +0xbf
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler(0x2494400, {0x2485000, 0xc00069f4a0}, {{{0xc00037a640, 0xe}, {0xc0000612c0, 0x12}}})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.4/pkg/internal/controller/controller.go:303 +0x3a5
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x2494400, {0x2485000, 0xc00069f4a0})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.4/pkg/internal/controller/controller.go:263 +0x20e
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.4/pkg/internal/controller/controller.go:224 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2 in goroutine 48
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.4/pkg/internal/controller/controller.go:220 +0x490

```

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A concurrent access to map in the certificate bundle controller has been fixed. 
```
