### PR TITLE
Clean up TODOs in hack/ci-e2e-kind.sh

### DIFF
--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -24,17 +24,12 @@ clamp_mss_to_pmtu() {
 }
 
 REPO_ROOT="$(readlink -f $(dirname ${0})/..)"
-# TODO: revert this once g/g releases 1.112.0
-# GARDENER_VERSION=$(go list -m -f '{{.Version}}' github.com/gardener/gardener)
-GARDENER_VERSION="44bea26b58a5ca7afd7241e539b5032d3e264716"
-
+GARDENER_VERSION=$(go list -m -f '{{.Version}}' github.com/gardener/gardener)
 
 ensure_glgc_resolves_to_localhost
 
 if [[ ! -d "$REPO_ROOT/gardener" ]]; then
-  # TODO: revert this once g/g releases 1.112.0
-  # git clone --branch $GARDENER_VERSION https://github.com/gardener/gardener.git
-  git clone https://github.com/gardener/gardener.git && cd "$REPO_ROOT/gardener" &&  git checkout $GARDENER_VERSION && cd "$REPO_ROOT"
+  git clone --branch $GARDENER_VERSION https://github.com/gardener/gardener.git
 else
   (cd "$REPO_ROOT/gardener" && git checkout $GARDENER_VERSION)
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Minor update - clean up TODOs in hack/ci-e2e-kind.sh related to logic prior g/g version 1.112.0 

/kind cleanup

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
