### PR TITLE
Disable `TLS_ECDHE_RSA_WITH_AES_(128|256)_CBC_SHA` cipher suites

### DIFF
--- a/cmd/discovery-server/app/app.go
+++ b/cmd/discovery-server/app/app.go
@@ -274,16 +274,19 @@ func runServer(ctx context.Context, log logr.Logger, srv *http.Server) error {
 }
 
 // getCipherSuiteIDs returns the default cipher suite IDs excluding:
-// - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
-// - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
-// - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-// - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+//   - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+//   - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+//   - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+//   - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
 func getCipherSuiteIDs() []uint16 {
+	ciphersToRemove := []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+	}
 	cipherSuites := slices.DeleteFunc(tls.CipherSuites(), func(cs *tls.CipherSuite) bool {
-		return cs.ID == tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA ||
-			cs.ID == tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA ||
-			cs.ID == tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA ||
-			cs.ID == tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+		return slices.Contains(ciphersToRemove, cs.ID)
 	})
 
 	cipherIDs := make([]uint16, 0, len(cipherSuites))

--- a/cmd/discovery-server/app/app.go
+++ b/cmd/discovery-server/app/app.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -211,7 +212,8 @@ func run(ctx context.Context, log logr.Logger, conf *options.Config) error {
 			GetCertificate: cert.GetCertificate,
 			// TODO: remove in the future
 			// gosec complains although 1.2 is the current default
-			MinVersion: tls.VersionTLS12,
+			MinVersion:   tls.VersionTLS12,
+			CipherSuites: getCipherSuiteIDs(),
 		},
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
@@ -269,4 +271,21 @@ func runServer(ctx context.Context, log logr.Logger, srv *http.Server) error {
 		log.Info("Shutdown successful")
 		return nil
 	}
+}
+
+// getCipherSuiteIDs returns the default cipher suite IDs excluding:
+// - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+// - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+func getCipherSuiteIDs() []uint16 {
+	cipherSuites := slices.DeleteFunc(tls.CipherSuites(), func(cs *tls.CipherSuite) bool {
+		return cs.ID == tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA ||
+			cs.ID == tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+	})
+
+	cipherIDs := make([]uint16, 0, len(cipherSuites))
+	for _, cipher := range cipherSuites {
+		cipherIDs = append(cipherIDs, cipher.ID)
+	}
+
+	return cipherIDs
 }

--- a/cmd/discovery-server/app/app.go
+++ b/cmd/discovery-server/app/app.go
@@ -276,10 +276,14 @@ func runServer(ctx context.Context, log logr.Logger, srv *http.Server) error {
 // getCipherSuiteIDs returns the default cipher suite IDs excluding:
 // - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
 // - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+// - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+// - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
 func getCipherSuiteIDs() []uint16 {
 	cipherSuites := slices.DeleteFunc(tls.CipherSuites(), func(cs *tls.CipherSuite) bool {
 		return cs.ID == tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA ||
-			cs.ID == tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+			cs.ID == tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA ||
+			cs.ID == tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA ||
+			cs.ID == tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
 	})
 
 	cipherIDs := make([]uint16, 0, len(cipherSuites))

--- a/cmd/discovery-server/app/app_suite_test.go
+++ b/cmd/discovery-server/app/app_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestApp(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "App Test Suite")
+}

--- a/cmd/discovery-server/app/app_test.go
+++ b/cmd/discovery-server/app/app_test.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"crypto/tls"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("App", func() {
+	Context("getCipherSuiteIDs", func() {
+		It("should return the default cipher suite IDs excluding the ones with CBC mode", func() {
+			cipherIDs := getCipherSuiteIDs()
+			Expect(cipherIDs).ToNot(ContainElement(tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA))
+			Expect(cipherIDs).ToNot(ContainElement(tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA))
+			Expect(cipherIDs).ToNot(ContainElement(tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA))
+			Expect(cipherIDs).ToNot(ContainElement(tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA))
+			Expect(cipherIDs).ToNot(BeEmpty())
+		})
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

The following TLS cipher suites are disabled:

- `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`
- `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA`
- `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA`
- `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA`

These CBC-mode cipher suites are susceptible to padding oracle attacks. PCI DSS v4.0 (Requirement 4.2.1 / 12.3.3) mandates the use of strong cryptography, and CBC-mode TLS cipher suites are consistently flagged as weak by PCI-approved scanning vendors (ASVs) during compliance scans. Retaining them can result in scan failures and block certification.

All modern TLS clients support the remaining GCM and ChaCha20-Poly1305 suites, so removing these introduces no compatibility risk for our use case.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The TLS cipher suites `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`, `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA`, `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA` and `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA` available in TLS up to v1.2, have been unconditionally disabled.
```
