### PR TITLE
Add support for (local) multiplatform container images build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# builder
-FROM golang:1.26.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.1 AS builder
 
-ARG TARGETARCH
 WORKDIR /go/src/github.com/gardener/gardener-discovery-server
 
 # Copy go mod and sum files
@@ -16,11 +15,13 @@ RUN go mod download
 COPY . .
 
 ARG EFFECTIVE_VERSION
-RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
+ARG TARGETOS
+ARG TARGETARCH
+RUN make build EFFECTIVE_VERSION=$EFFECTIVE_VERSION GOOS=$TARGETOS GOARCH=$TARGETARCH BUILD_OUTPUT_FILE="/output/bin/"
 
 ############# gardener-discovery-server
 FROM gcr.io/distroless/static-debian13:nonroot AS gardener-discovery-server
 WORKDIR /
 
-COPY --from=builder /go/bin/discovery-server /gardener-discovery-server
+COPY --from=builder /output/bin/discovery-server /gardener-discovery-server
 ENTRYPOINT ["/gardener-discovery-server"]

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ GOARCH                      ?= $(shell go env GOARCH)
 EFFECTIVE_VERSION           := $(VERSION)-$(shell git rev-parse HEAD)
 LD_FLAGS                    := "-w $(shell bash $(GARDENER_HACK_DIR)/get-build-ld-flags.sh k8s.io/component-base $(REPO_ROOT)/VERSION $(NAME))"
 PARALLEL_E2E_TESTS          := 2
+TARGET_PLATFORMS            ?= linux/$(shell go env GOARCH)
 
 ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
 	EFFECTIVE_VERSION := $(EFFECTIVE_VERSION)-dirty
@@ -36,10 +37,16 @@ install:
 	@LD_FLAGS=$(LD_FLAGS) EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) \
 		bash $(GARDENER_HACK_DIR)/install.sh ./...
 
+BUILD_OUTPUT_FILE ?= .
+
+.PHONY: build
+build:
+	@LD_FLAGS=$(LD_FLAGS) EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) \
+		bash $(GARDENER_HACK_DIR)/build.sh -o $(BUILD_OUTPUT_FILE) ./cmd/discovery-server
 
 .PHONY: docker-images
 docker-images:
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) --build-arg TARGETARCH=$(GOARCH) -t $(IMAGE):$(EFFECTIVE_VERSION) -t $(IMAGE):latest -f Dockerfile -m 6g --target $(NAME) .
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) --platform=$(TARGET_PLATFORMS) -t $(IMAGE):$(EFFECTIVE_VERSION) -t $(IMAGE):latest -f Dockerfile -m 6g --target $(NAME) .
 
 #####################################################################
 # Rules for verification, formatting, linting, testing and cleaning #


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Add support for (local) multiplatform container images build

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Similar to https://github.com/gardener/gardener/pull/13324/

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The Gardener Discovery server container image now can be built for multiple platforms locally via the variable `TARGET_PLATFORMS`, e.g. `make docker-images TARGET_PLATFORMS=linux/amd64,linux/arm64`. If the variable is unset, the container images are built for the platform `linux/<host-arch>` only.
```
