### PR TITLE
Add CODEOWNERS file and restrict non-release push trigger to main and release branches only

### DIFF
--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -1,6 +1,9 @@
 name: Build
 on:
   push:
+    branches:
+      - main
+      - 'release-v*'
   pull_request:
 
 jobs:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# gardener-discovery-server maintainers
+*   @gardener/gardener-discovery-server-maintainers


### PR DESCRIPTION
**What this PR does / why we need it**:
Add CODEOWNERS file and restrict non-release push trigger to main and release branches only

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```

/cc @dimityrmirchev @theoddora 
