### PR TITLE
Prepare openidmeta controller migration from `authentication.gardener.cloud/public-keys` to `discovery.gardener.cloud/public` secret label key

### DIFF
--- a/internal/reconciler/certificate/add.go
+++ b/internal/reconciler/certificate/add.go
@@ -7,6 +7,7 @@ package certificate
 import (
 	"time"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
@@ -60,10 +61,9 @@ func isRelevantConfigMap(obj client.Object) bool {
 	}
 	// we only allow update-restricted resources
 	// it is not safe to read data from resources that might be modified by users
-	// TODO: Use v1beta1constants.(LabelDiscoveryPublic|LabelUpdateRestriction) for label keys when gardener is updated to >= v1.112.0
 	return configmap.Labels != nil &&
-		configmap.Labels["discovery.gardener.cloud/public"] == "shoot-ca" &&
-		configmap.Labels["gardener.cloud/update-restriction"] == "true"
+		configmap.Labels[v1beta1constants.LabelDiscoveryPublic] == v1beta1constants.DiscoveryShootCA &&
+		configmap.Labels[v1beta1constants.LabelUpdateRestriction] == "true"
 }
 
 func isRelevantConfigMapUpdate(oldObj, newObj client.Object) bool {

--- a/internal/reconciler/openidmeta/add.go
+++ b/internal/reconciler/openidmeta/add.go
@@ -59,7 +59,7 @@ func isRelevantSecret(obj client.Object) bool {
 	if !ok {
 		return false
 	}
-	return secret.Labels != nil && secret.Labels[v1beta1constants.LabelPublicKeys] == v1beta1constants.LabelPublicKeysServiceAccount //nolint:staticcheck
+	return secret.Labels != nil && secret.Labels[v1beta1constants.LabelDiscoveryPublic] == v1beta1constants.LabelPublicKeysServiceAccount
 }
 
 func isRelevantSecretUpdate(oldObj, newObj client.Object) bool {

--- a/internal/reconciler/openidmeta/add.go
+++ b/internal/reconciler/openidmeta/add.go
@@ -59,7 +59,10 @@ func isRelevantSecret(obj client.Object) bool {
 	if !ok {
 		return false
 	}
-	return secret.Labels != nil && secret.Labels[v1beta1constants.LabelDiscoveryPublic] == v1beta1constants.LabelPublicKeysServiceAccount
+	return secret.Labels != nil &&
+		(secret.Labels[v1beta1constants.LabelDiscoveryPublic] == v1beta1constants.LabelPublicKeysServiceAccount ||
+			// TODO(vpnachev): Remove v1beta1constants.LabelPublicKeys once support for gardener/gardener <= v1.142.0 is dropped.
+			secret.Labels[v1beta1constants.LabelPublicKeys] == v1beta1constants.LabelPublicKeysServiceAccount) //nolint:staticcheck
 }
 
 func isRelevantSecretUpdate(oldObj, newObj client.Object) bool {

--- a/internal/reconciler/openidmeta/metadata.go
+++ b/internal/reconciler/openidmeta/metadata.go
@@ -73,8 +73,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	labels := secret.GetLabels()
-	if v, ok := labels[v1beta1constants.LabelPublicKeys]; !ok || v != v1beta1constants.LabelPublicKeysServiceAccount { //nolint:staticcheck
-		log.Info("Removing metadata from store - secret does not have expected label or its value is incorrect", "label", v1beta1constants.LabelPublicKeys, "value", v) //nolint:staticcheck
+	if v, ok := labels[v1beta1constants.LabelDiscoveryPublic]; !ok || v != v1beta1constants.LabelPublicKeysServiceAccount {
+		log.Info("Removing metadata from store - secret does not have expected label or its value is incorrect", "label", v1beta1constants.LabelDiscoveryPublic, "value", v)
 		r.Store.Delete(req.Name)
 		return reconcile.Result{}, nil
 	}

--- a/internal/reconciler/openidmeta/metadata.go
+++ b/internal/reconciler/openidmeta/metadata.go
@@ -73,8 +73,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	labels := secret.GetLabels()
+	shouldRemoveMetadata := false
 	if v, ok := labels[v1beta1constants.LabelDiscoveryPublic]; !ok || v != v1beta1constants.LabelPublicKeysServiceAccount {
-		log.Info("Removing metadata from store - secret does not have expected label or its value is incorrect", "label", v1beta1constants.LabelDiscoveryPublic, "value", v)
+		log.Info("Considering metadata for removal from the store - secret does not have expected label or its value is incorrect")
+		shouldRemoveMetadata = true
+	}
+
+	// TODO(vpnachev): Remove the fallback to v1beta1constants.LabelPublicKeys once support for gardener/gardener <= v1.142.0 is dropped.
+	if v, ok := labels[v1beta1constants.LabelPublicKeys]; shouldRemoveMetadata && ok && v == v1beta1constants.LabelPublicKeysServiceAccount { //nolint:staticcheck
+		log.Info("Metadata will not be removed from the store - found the deprecated label with expected value, this is for backward compatibility with gardener/gardener <= v1.142.0")
+		shouldRemoveMetadata = false
+	}
+
+	if shouldRemoveMetadata {
+		log.Info("Removing metadata from store - secret does not have any of the expected labels or their values are incorrect", "label", v1beta1constants.LabelDiscoveryPublic, "value", labels[v1beta1constants.LabelDiscoveryPublic],
+			"alternativeLabel", v1beta1constants.LabelPublicKeys, "alternativeValue", labels[v1beta1constants.LabelPublicKeys]) //nolint:staticcheck
 		r.Store.Delete(req.Name)
 		return reconcile.Result{}, nil
 	}

--- a/internal/reconciler/openidmeta/metadata_test.go
+++ b/internal/reconciler/openidmeta/metadata_test.go
@@ -159,6 +159,26 @@ var _ = Describe("#ReconcileOpenIDMeta", func() {
 		})
 	})
 
+	// TODO(vpnachev): Remove this test once support for gardener/gardener <= v1.142.0 is dropped.
+	It("should write entry to store when the deprecated label is used", func() {
+		delete(secret.Labels, "discovery.gardener.cloud/public")
+		secret.Labels["authentication.gardener.cloud/public-keys"] = "serviceaccount"
+
+		Expect(c.Create(ctx, project)).To(Succeed())
+		Expect(c.Create(ctx, shoot)).To(Succeed())
+		Expect(c.Create(ctx, secret)).To(Succeed())
+
+		res, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(secret)})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(Equal(ctrl.Result{RequeueAfter: resyncPeriod}))
+
+		Expect(s.Len()).To(Equal(1))
+		expectStoreEntry(s, secret.Name, oidstore.Data{
+			Config: []byte(`{"issuer":"https://foo","jwks_uri":"https://foo/jwks"}`),
+			JWKS:   expectedJWKSBytes,
+		})
+	})
+
 	DescribeTable(
 		"should remove entry from store because of failed validation",
 		func(prepFunc func()) {

--- a/internal/reconciler/openidmeta/metadata_test.go
+++ b/internal/reconciler/openidmeta/metadata_test.go
@@ -123,10 +123,10 @@ var _ = Describe("#ReconcileOpenIDMeta", func() {
 				Name:      project.Name + "--" + string(shoot.UID),
 				Namespace: "gardener-system-shoot-issuer",
 				Labels: map[string]string{
-					"authentication.gardener.cloud/public-keys": "serviceaccount",
-					"project.gardener.cloud/name":               project.Name,
-					"shoot.gardener.cloud/name":                 shoot.Name,
-					"shoot.gardener.cloud/namespace":            shoot.Namespace,
+					"discovery.gardener.cloud/public": "serviceaccount",
+					"project.gardener.cloud/name":     project.Name,
+					"shoot.gardener.cloud/name":       shoot.Name,
+					"shoot.gardener.cloud/namespace":  shoot.Namespace,
 				},
 			},
 			Data: map[string][]byte{
@@ -187,12 +187,12 @@ var _ = Describe("#ReconcileOpenIDMeta", func() {
 		Entry("secret is missing", func() {
 			Expect(c.Delete(ctx, secret)).To(Succeed())
 		}),
-		Entry("secret is not labeled with authentication.gardener.cloud/public-keys", func() {
-			delete(secret.Labels, "authentication.gardener.cloud/public-keys")
+		Entry("secret is not labeled with discovery.gardener.cloud/public", func() {
+			delete(secret.Labels, "discovery.gardener.cloud/public")
 			Expect(c.Update(ctx, secret)).To(Succeed())
 		}),
-		Entry("secret label authentication.gardener.cloud/public-keys does not have correct value", func() {
-			secret.Labels["authentication.gardener.cloud/public-keys"] = "wrong"
+		Entry("secret label discovery.gardener.cloud/public does not have correct value", func() {
+			secret.Labels["discovery.gardener.cloud/public"] = "wrong"
 			Expect(c.Update(ctx, secret)).To(Succeed())
 		}),
 		Entry("secret does not have openid-config data entry", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Prepare openidmeta controller migration from `authentication.gardener.cloud/public-keys` to `discovery.gardener.cloud/public` secret label key.

https://github.com/gardener/gardener/pull/11224/ has deprecated the `authentication.gardener.cloud/public-keys` in favor of `discovery.gardener.cloud/public`. With https://github.com/gardener/gardener/pull/14670, Gardener will start to label the openidmeta secrets with the new label and will drop the deprecated one after v1.144.0 is released, therefore the controller will maintain backward compatibility for some time to ensure smooth migration. 


/kind enhancement

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
~~The pr is based on #191, first 5 commits should be ignored. ~~

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add support for OIDC discovery secrets labeled with `discovery.gardener.cloud/public=serviceaccount` to the `openidmeta` controller. 
```

```breaking operator
⚠️ Support for OIDC discovery secrets labeled with `authentication.gardener.cloud/public-keys=serviceaccount` is deprecated and will be removed in a future version. Consider migrating to the `discovery.gardener.cloud/public=serviceaccount` label.
```
