### PR TITLE
ci: Build and push the helm chart as OCI image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,7 @@ jobs:
     name: Build OCI-Images
     needs:
       - prepare
+      - verify
     permissions:
       contents: read
       packages: write
@@ -102,3 +103,44 @@ jobs:
                 - name: gardener.cloud/purposes
                   value:
                     - test
+
+  helmcharts:
+    name: Build Helmcharts
+    needs:
+      - prepare
+      - oci-images
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    uses: gardener/cc-utils/.github/workflows/helmchart-ocm.yaml@v1
+    strategy:
+      matrix:
+        args:
+          - name: discovery-server
+            dir: charts/discovery-server
+            oci-repository: charts/gardener/gardener-discovery-server
+            ocm-mappings:
+              - ref: ocm-resource:discovery-server.repository
+                attribute: runtime.image.repository
+              - ref: ocm-resource:discovery-server.tag
+                attribute: runtime.image.tag
+    with:
+      name: ${{ matrix.args.name }}
+      dir: ${{ matrix.args.dir }}
+      oci-registry: ${{ needs.prepare.outputs.oci-registry }}
+      oci-repository: ${{ matrix.args.oci-repository }}
+      ocm-mappings: ${{ toJSON(matrix.args.ocm-mappings) }}
+
+  helmcharts-summary:
+    name: Helm Charts Summary
+    runs-on: ubuntu-latest
+    needs:
+    - helmcharts
+    if: ${{ always() }}  # Ensures this job runs even if the matrix partially fails
+    permissions:
+      contents: read
+    steps:
+      - name: Fail if Helm Charts matrix failed
+        if: ${{ needs.helmcharts.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -117,13 +117,13 @@ jobs:
     strategy:
       matrix:
         args:
-          - name: discovery-server
+          - name: gardener-discovery-server
             dir: charts/discovery-server
             oci-repository: charts/gardener/gardener-discovery-server
             ocm-mappings:
-              - ref: ocm-resource:discovery-server.repository
+              - ref: ocm-resource:gardener-discovery-server.repository
                 attribute: runtime.image.repository
-              - ref: ocm-resource:discovery-server.tag
+              - ref: ocm-resource:gardener-discovery-server.tag
                 attribute: runtime.image.tag
     with:
       name: ${{ matrix.args.name }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,6 +56,19 @@ jobs:
       target: ${{ matrix.args.target }}
       extra-tags: latest
 
+  oci-images-summary:
+    name: OCI Images Summary
+    runs-on: ubuntu-latest
+    needs:
+    - oci-images
+    if: ${{ always() }}  # Ensures this job runs even if the matrix partially fails
+    permissions:
+      contents: read
+    steps:
+      - name: Fail if OCI matrix failed
+        if: ${{ needs.oci-images.result != 'success' }}
+        run: exit 1
+
   verify:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -132,7 +132,7 @@ jobs:
         args:
           - name: gardener-discovery-server
             dir: charts/discovery-server
-            oci-repository: charts/gardener/gardener-discovery-server
+            oci-repository: charts/gardener
             ocm-mappings:
               - ref: ocm-resource:gardener-discovery-server.repository
                 attribute: runtime.image.repository

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -1,4 +1,4 @@
-name: Build
+name: Non-Release
 on:
   push:
     branches:


### PR DESCRIPTION
**What this PR does / why we need it**:
ci: Build and push the helm chart as OCI image

Also make oci-images build to depend on verify

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The helm chart is made available as OCI image via `europe-docker.pkg.dev/gardener-project/public/charts/gardener/gardener-discovery-server`.
```
