### PR TITLE
Adapt VPA resources to explicitly specify update mode `InPlaceOrRecreate`

### DIFF
--- a/charts/discovery-server/charts/runtime/values.yaml
+++ b/charts/discovery-server/charts/runtime/values.yaml
@@ -30,7 +30,7 @@ vpa:
     minAllowed:
       memory: 64Mi
   updatePolicy:
-    updateMode: "Recreate"
+    updateMode: "InPlaceOrRecreate"
 
 # Kubeconfig to the target cluster. In-cluster configuration will be used if not specified.
 kubeconfig:

--- a/charts/discovery-server/values.yaml
+++ b/charts/discovery-server/values.yaml
@@ -36,7 +36,7 @@ runtime:
       minAllowed:
         memory: 64Mi
     updatePolicy:
-      updateMode: "Recreate"
+      updateMode: "InPlaceOrRecreate"
 
   # Kubeconfig to the target cluster. In-cluster configuration will be used if not specified.
   kubeconfig:

--- a/example/local/values.yaml
+++ b/example/local/values.yaml
@@ -32,6 +32,6 @@ runtime:
       minAllowed:
         memory: 64Mi
     updatePolicy:
-      updateMode: "Recreate"
+      updateMode: "InPlaceOrRecreate"
 
   kubeconfig:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Gardener's `VPAInPlaceUpdates` feature gate has been promoted and unconditionally enabled. This unconditionally enables the Gardener Resource
  Manager's `vpa-in-place-updates` admission webhook, which was previously mutating the value from `Recreate` to `InPlaceOrRecreate` at admission
  time. This change makes the extension explicitly set the correct value, aligning the code with the actual runtime behavior and removing the implicit
  dependency on the webhook mutation.

**Which issue(s) this PR fixes**:

Part of gardener/gardener#12955

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The update mode of the VerticalPodAutoscaler resources deployed by the gardener-discovery-server is now explicitly set to `InPlaceOrRecreate`, reflecting the actual runtime behavior after the unconditional enablement of the `VPAInPlaceUpdates` feature gate.
```
