### PR TITLE
Drop support for secrets labeled with `authentication.gardener.cloud/public-keys=serviceaccount`

### DIFF
--- a/internal/reconciler/openidmeta/add.go
+++ b/internal/reconciler/openidmeta/add.go
@@ -59,10 +59,7 @@ func isRelevantSecret(obj client.Object) bool {
 	if !ok {
 		return false
 	}
-	return secret.Labels != nil &&
-		(secret.Labels[v1beta1constants.LabelDiscoveryPublic] == v1beta1constants.LabelPublicKeysServiceAccount ||
-			// TODO(vpnachev): Remove "authentication.gardener.cloud/public-keys" once support for gardener/gardener <= v1.142.0 is dropped.
-			secret.Labels["authentication.gardener.cloud/public-keys"] == v1beta1constants.LabelPublicKeysServiceAccount) //nolint:staticcheck
+	return secret.Labels != nil && secret.Labels[v1beta1constants.LabelDiscoveryPublic] == v1beta1constants.LabelPublicKeysServiceAccount
 }
 
 func isRelevantSecretUpdate(oldObj, newObj client.Object) bool {

--- a/internal/reconciler/openidmeta/metadata.go
+++ b/internal/reconciler/openidmeta/metadata.go
@@ -73,21 +73,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	labels := secret.GetLabels()
-	shouldRemoveMetadata := false
-	if v, ok := labels[v1beta1constants.LabelDiscoveryPublic]; !ok || v != v1beta1constants.LabelPublicKeysServiceAccount {
-		log.Info("Considering metadata for removal from the store - secret does not have expected label or its value is incorrect")
-		shouldRemoveMetadata = true
-	}
-
-	// TODO(vpnachev): Remove the fallback to "authentication.gardener.cloud/public-keys" once support for gardener/gardener <= v1.142.0 is dropped.
-	if v, ok := labels["authentication.gardener.cloud/public-keys"]; shouldRemoveMetadata && ok && v == v1beta1constants.LabelPublicKeysServiceAccount { //nolint:staticcheck
-		log.Info("Metadata will not be removed from the store - found the deprecated label with expected value, this is for backward compatibility with gardener/gardener <= v1.142.0")
-		shouldRemoveMetadata = false
-	}
-
-	if shouldRemoveMetadata {
-		log.Info("Removing metadata from store - secret does not have any of the expected labels or their values are incorrect", "label", v1beta1constants.LabelDiscoveryPublic, "value", labels[v1beta1constants.LabelDiscoveryPublic],
-			"alternativeLabel", "authentication.gardener.cloud/public-keys", "alternativeValue", labels["authentication.gardener.cloud/public-keys"]) //nolint:staticcheck
+	if value, ok := labels[v1beta1constants.LabelDiscoveryPublic]; !ok || value != v1beta1constants.LabelPublicKeysServiceAccount {
+		log.Info("Removing metadata from store - secret does not have expected label or its value is incorrect", "label", v1beta1constants.LabelDiscoveryPublic, "value", value)
 		r.Store.Delete(req.Name)
 		return reconcile.Result{}, nil
 	}

--- a/internal/reconciler/openidmeta/metadata_test.go
+++ b/internal/reconciler/openidmeta/metadata_test.go
@@ -159,26 +159,6 @@ var _ = Describe("#ReconcileOpenIDMeta", func() {
 		})
 	})
 
-	// TODO(vpnachev): Remove this test once support for gardener/gardener <= v1.142.0 is dropped.
-	It("should write entry to store when the deprecated label is used", func() {
-		delete(secret.Labels, "discovery.gardener.cloud/public")
-		secret.Labels["authentication.gardener.cloud/public-keys"] = "serviceaccount"
-
-		Expect(c.Create(ctx, project)).To(Succeed())
-		Expect(c.Create(ctx, shoot)).To(Succeed())
-		Expect(c.Create(ctx, secret)).To(Succeed())
-
-		res, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(secret)})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(res).To(Equal(ctrl.Result{RequeueAfter: resyncPeriod}))
-
-		Expect(s.Len()).To(Equal(1))
-		expectStoreEntry(s, secret.Name, oidstore.Data{
-			Config: []byte(`{"issuer":"https://foo","jwks_uri":"https://foo/jwks"}`),
-			JWKS:   expectedJWKSBytes,
-		})
-	})
-
 	DescribeTable(
 		"should remove entry from store because of failed validation",
 		func(prepFunc func()) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Drop support for secrets labeled with `authentication.gardener.cloud/public-keys=serviceaccount`

/kind cleanup

**Which issue(s) this PR fixes**:
Follow-up on https://github.com/gardener/gardener-discovery-server/pull/196/
Related to https://github.com/gardener/gardener/pull/15244 and https://github.com/gardener/gardener/pull/14670

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
:warning: Gardener Discovery server no longer supports Gardener `< v1.143.0`, please update Gardener to version `>= v1.143.0` before updating to this version of the discovery server.
```
